### PR TITLE
Revamp the service account support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV GOOS=linux
 COPY . /src
 WORKDIR /src
 RUN make test
-RUN make vulncheck
+RUN make check
 RUN make alpine
 
 FROM alpine:3.15

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,6 @@ migrate:
 test:
 	go test ./...
 
-vulncheck:
-	go run golang.org/x/vuln/cmd/govulncheck -v ./...
-
 fmt:
 	go run mvdan.cc/gofumpt -w ./
 
@@ -26,6 +23,7 @@ generate: generate-sqlc generate-gql generate-mocks
 
 check:
 	go run honnef.co/go/tools/cmd/staticcheck ./...
+	go run golang.org/x/vuln/cmd/govulncheck -v ./...
 
 generate-gql:
 	go run github.com/99designs/gqlgen generate --verbose

--- a/adr/002-users-and-service-accounts.md
+++ b/adr/002-users-and-service-accounts.md
@@ -19,7 +19,7 @@ Console considers the tenants GCP organization to be the single source of truth 
 When a user is removed from the GCP organization, the user sync will remove the user from the Console database, along with all existing team connections and other relations.
 
 ### Service accounts
-A service account corresponds to one (or several) external systems, and is identified through a unique name. The name must start with a lowercase letter, and can consist of lowercase letters, numbers and hyppens. The name can not end with a hyphen. Service accounts must use API keys to interact with the GraphQL API, and are not able to sign in using the frontend.
+A service account corresponds to one (or several) external systems, and is identified through a unique name. The name must start with a lowercase letter, and can consist of lowercase letters, numbers and hyphens. The name can not end with a hyphen. Service accounts must use API keys to interact with the GraphQL API, and are not able to sign in using the frontend.
 
 Service accounts can only be created via the `CONSOLE_STATIC_SERVICE_ACCOUNTS` environment variable that must be passed to Console on startup. The environment variable must contain a JSON string that matches the following schema:
 

--- a/adr/002-users-and-service-accounts.md
+++ b/adr/002-users-and-service-accounts.md
@@ -1,0 +1,83 @@
+# ADR - Users and service accounts
+**TL;DR** *A service account is a type of user that is used by other systems to interact with the Console GraphQL API, while a user is a developer that interacts with Console through the frontend UI. Service accounts authenticate using API keys, while users authenticate using OAuth 2.0.*
+
+## Background
+Console exposes a [GraphQL API](https://graphql.org/) that can be used to do team-related interactions. To be able to access this API in a controlled manner we need a concept surrounding users and authentication. Authorization is beyond the scope of this ADR.
+
+## Solution
+Console has two different classes of users:
+
+- Regular users (developers)
+- Service accounts (machines)
+
+### Users
+A user corresponds to a developer, and is identified through a unique email address. Users will not typically interact with Console through the GraphQL API directly, but instead through the [Console frontend UI](https://github.com/nais/console-frontend-elm). For a user to exist in Console it needs to be synced from the tenants GCP organization. Console stores the name and email address of each user entry.
+
+#### User sync
+Console considers the tenants GCP organization to be the single source of truth when it comes to user accounts, and will continuously syncronize all users from GCP to Console. It is not possible to manually create Console user accounts through the GraphQL API, so the only way to add users to Console is through the user sync. It is not possible to update existing user information in Console through the API either, this must be done in the GCP organization, and changes to user accounts will be mirrored to the user accounts in Console through the user sync.
+
+When a user is removed from the GCP organization, the user sync will remove the user from the Console database, along with all existing team connections and other relations.
+
+### Service accounts
+A service account corresponds to one (or several) external systems, and is identified through a unique name. The name must start with a lowercase letter, and can consist of lowercase letters, numbers and hyppens. The name can not end with a hyphen. Service accounts must use API keys to interact with the GraphQL API, and are not able to sign in using the frontend.
+
+Service accounts can only be created via the `CONSOLE_STATIC_SERVICE_ACCOUNTS` environment variable that must be passed to Console on startup. The environment variable must contain a JSON string that matches the following schema:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/nais/console/service-accounts-schema.json",
+  "title": "Service accounts",
+  "description": "JSON array for creating service accounts during Console startup",
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The unique name of the service account. Must have the `nais-` prefix.",
+          "type": "string"
+        },
+        "apiKey": {
+          "description": "The API key of the service account.",
+          "type": "string"
+        },
+        "roles": {
+          "description": "Roles that will be granted to the service account.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "name",
+        "apiKey",
+        "roles"
+      ]
+    }
+  ]
+}
+```
+
+Following is an example value that would end up creating two different service accounts, with different API keys and different roles:
+
+```json
+[
+  {
+    "name": "nais-service-account-1",
+    "apiKey": "api-key-1",
+    "roles": ["Team viewer"]
+  },
+  {
+    "name": "nais-service-account-2",
+    "apiKey": "api-key-2",
+    "roles": ["Team owner"]
+  }
+]
+```
+
+The role names must be one of the supported roles in Console. A complete list of available roles can be fetched from the GraphQL API. When a service account is removed from the environment variable it will be removed when Console restarts.
+
+#### Limitations
+Service accounts are currently only meant to be used by the NAIS team, and service accounts are not allowed as team members / owners.

--- a/cmd/console/main.go
+++ b/cmd/console/main.go
@@ -72,7 +72,7 @@ func run() error {
 		return err
 	}
 
-	err = fixtures.InsertInitialDataset(ctx, database, cfg.TenantDomain, cfg.AdminApiKey)
+	err = fixtures.CreateAdminServiceAccount(ctx, database, cfg.AdminApiKey)
 	if err != nil {
 		return err
 	}
@@ -346,7 +346,7 @@ func setupGraphAPI(database db.Database, domain string, teamReconciler chan<- re
 	resolver := graph.NewResolver(database, domain, teamReconciler, auditLogger)
 	gc := generated.Config{}
 	gc.Resolvers = resolver
-	gc.Directives.Auth = directives.Auth(database)
+	gc.Directives.Auth = directives.Auth()
 	gc.Complexity.User.Teams = func(childComplexity int) int {
 		return 10 * childComplexity
 	}

--- a/graphql/auditlogs.graphqls
+++ b/graphql/auditlogs.graphqls
@@ -9,14 +9,14 @@ type AuditLog {
     "The related system."
     systemName: SystemName!
 
-    "The related correlation."
+    "The related correlation ID."
     correlationID: UUID!
 
-    "The email address of the actor who performed the action. When this field is empty it means that some backend process performed the action."
-    actorEmail: String
+    "The identity of the actor who performed the action. When this field is empty it means that some backend process performed the action. The value, when present, is either the name of a service account, or the email address of a user."
+    actor: String
 
-    "The email address of the target user, if any."
-    targetUserEmail: String
+    "The target user, if any. For service accounts this is the name of the service account, while for users this will be the email address of the user."
+    targetUser: String
 
     "The target team slug, if any."
     targetTeamSlug: Slug

--- a/graphql/authentication.graphqls
+++ b/graphql/authentication.graphqls
@@ -1,0 +1,7 @@
+extend type Query {
+    "The currently authenticated user."
+    me: AuthenticatedUser! @auth
+}
+
+"Authenticated user type. Can be a user or a service account."
+union AuthenticatedUser = User | ServiceAccount

--- a/graphql/serviceAccounts.graphqls
+++ b/graphql/serviceAccounts.graphqls
@@ -1,0 +1,11 @@
+"Service account type."
+type ServiceAccount {
+    "Unique ID of the service account."
+    id: UUID!
+
+    "The name of the service account."
+    name: String!
+
+    "Roles attached to the service account."
+    roles: [Role!]!
+}

--- a/graphql/teams.graphqls
+++ b/graphql/teams.graphqls
@@ -13,7 +13,7 @@ extend type Mutation {
     """
     Create a new team
 
-    The user creating the team will be granted team ownership.
+    The user creating the team will be granted team ownership, unless the user is a service account, in which case the team will not get an initial owner. To add one or more owners to the team, refer to the `addTeamOwners` mutation.
 
     The new team will be returned on success.
     """
@@ -145,6 +145,15 @@ type SyncError {
 
     "Error message."
     error: String!
+}
+
+"Team membership type."
+type TeamMembership {
+    "Team instance."
+    team: Team!
+
+    "The role that the member has in the team."
+    role: TeamRole!
 }
 
 "Team member."

--- a/graphql/users.graphqls
+++ b/graphql/users.graphqls
@@ -13,9 +13,6 @@ extend type Query {
         "ID of the user."
         email: String!
     ): User! @auth
-
-    "The currently authenticated user."
-    me: User! @auth
 }
 
 "User type."
@@ -29,18 +26,9 @@ type User {
     "The name of the user."
     name: String!
 
-    "List of teams the user is a member of."
-    teams: [UserTeam!]!
+    "List of team memberships."
+    teams: [TeamMembership!]!
 
     "Roles attached to the user."
     roles: [Role!]!
-}
-
-"User team."
-type UserTeam {
-    "Team instance."
-    team: Team!
-
-    "The role that the user has in the team."
-    role: TeamRole!
 }

--- a/pkg/auditlogger/logger.go
+++ b/pkg/auditlogger/logger.go
@@ -37,11 +37,11 @@ func New(database db.Database) AuditLogger {
 }
 
 type Fields struct {
-	Action          sqlc.AuditAction
-	CorrelationID   uuid.UUID
-	ActorEmail      *string
-	TargetTeamSlug  *slug.Slug
-	TargetUserEmail *string
+	Action         sqlc.AuditAction
+	CorrelationID  uuid.UUID
+	Actor          *string
+	TargetTeamSlug *slug.Slug
+	TargetUser     *string
 }
 
 func (l *auditLogger) Logf(ctx context.Context, fields Fields, message string, messageArgs ...interface{}) error {
@@ -62,13 +62,13 @@ func (l *auditLogger) Logf(ctx context.Context, fields Fields, message string, m
 	}
 
 	message = fmt.Sprintf(message, messageArgs...)
-	err := l.database.AddAuditLog(
+	err := l.database.CreateAuditLogEntry(
 		ctx,
 		fields.CorrelationID,
 		l.systemName,
-		fields.ActorEmail,
+		fields.Actor,
 		fields.TargetTeamSlug,
-		fields.TargetUserEmail,
+		fields.TargetUser,
 		fields.Action,
 		message,
 	)
@@ -81,14 +81,14 @@ func (l *auditLogger) Logf(ctx context.Context, fields Fields, message string, m
 		"correlation_id": fields.CorrelationID,
 		"system_name":    l.systemName,
 	}
-	if fields.ActorEmail != nil {
-		logFields["actor_email"] = str(fields.ActorEmail)
+	if fields.Actor != nil {
+		logFields["actor"] = str(fields.Actor)
 	}
 	if fields.TargetTeamSlug != nil {
 		logFields["target_team_slug"] = str(fields.TargetTeamSlug.StringP())
 	}
-	if fields.TargetUserEmail != nil {
-		logFields["target_user_email"] = str(fields.TargetUserEmail)
+	if fields.TargetUser != nil {
+		logFields["target_user"] = str(fields.TargetUser)
 	}
 
 	log.StandardLogger().WithFields(logFields).Infof(message)

--- a/pkg/authz/authz.go
+++ b/pkg/authz/authz.go
@@ -14,7 +14,7 @@ import (
 type ContextKey string
 
 type actor struct {
-	User  *db.User
+	User  db.AuthenticatedUser
 	Roles []*db.Role
 }
 
@@ -29,7 +29,7 @@ func (u *actor) Authenticated() bool {
 const contextKeyUser ContextKey = "actor"
 
 // ContextWithActor Return a context with an actor attached to it.
-func ContextWithActor(ctx context.Context, user *db.User, roles []*db.Role) context.Context {
+func ContextWithActor(ctx context.Context, user db.AuthenticatedUser, roles []*db.Role) context.Context {
 	return context.WithValue(ctx, contextKeyUser, &actor{
 		User:  user,
 		Roles: roles,
@@ -102,7 +102,7 @@ func RequireAuthorizationOrTargetMatch(actor *actor, requiredAuthzName sqlc.Auth
 		return ErrNotAuthorized
 	}
 
-	if actor.User.ID == target {
+	if actor.User.GetID() == target {
 		return nil
 	}
 

--- a/pkg/authz/authz_test.go
+++ b/pkg/authz/authz_test.go
@@ -78,7 +78,7 @@ func TestRequireAuthorizationForTarget(t *testing.T) {
 		Name:  "User Name",
 		Email: "mail@example.com",
 	}
-	targetID, _ := uuid.NewUUID()
+	targetID := uuid.New()
 
 	t.Run("Nil user", func(t *testing.T) {
 		assert.ErrorIs(t, authz.RequireAuthorization(nil, sqlc.AuthzNameTeamsCreate, targetID), authz.ErrNotAuthorized)

--- a/pkg/azureclient/azureclient_test.go
+++ b/pkg/azureclient/azureclient_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+
 	"github.com/nais/console/pkg/azureclient"
 	helpers "github.com/nais/console/pkg/console"
 	"github.com/nais/console/pkg/reconcilers"
@@ -65,7 +66,7 @@ func Test_GetUserWithInvalidApiResponse(t *testing.T) {
 }
 
 func Test_GetGroupById(t *testing.T) {
-	groupId := newUuid()
+	groupId := uuid.New()
 	httpClient := test.NewTestHttpClient(func(req *http.Request) *http.Response {
 		assert.Equal(t, "https://graph.microsoft.com/v1.0/groups/"+groupId.String(), req.URL.String())
 		assert.Equal(t, http.MethodGet, req.Method)
@@ -85,7 +86,7 @@ func Test_GetGroupById(t *testing.T) {
 }
 
 func Test_GetGroupThatDoesNotExist(t *testing.T) {
-	groupId := newUuid()
+	groupId := uuid.New()
 	httpClient := test.NewTestHttpClient(func(req *http.Request) *http.Response {
 		assert.Equal(t, "https://graph.microsoft.com/v1.0/groups/"+groupId.String(), req.URL.String())
 		assert.Equal(t, http.MethodGet, req.Method)
@@ -220,7 +221,7 @@ func Test_GetOrCreateGroupWithEmptyState(t *testing.T) {
 }
 
 func Test_GetOrCreateGroupWhenGroupInStateDoesNotExist(t *testing.T) {
-	groupId := newUuid()
+	groupId := uuid.New()
 	httpClient := test.NewTestHttpClient(
 		func(req *http.Request) *http.Response {
 			assert.Equal(t, "https://graph.microsoft.com/v1.0/groups/"+groupId.String(), req.URL.String())
@@ -252,7 +253,7 @@ func Test_GetOrCreateGroupWhenGroupInStateDoesNotExist(t *testing.T) {
 }
 
 func Test_GetOrCreateGroupWhenGroupInStateExists(t *testing.T) {
-	groupId := newUuid()
+	groupId := uuid.New()
 	httpClient := test.NewTestHttpClient(
 		func(req *http.Request) *http.Response {
 			assert.Equal(t, "https://graph.microsoft.com/v1.0/groups/"+groupId.String(), req.URL.String())
@@ -440,9 +441,4 @@ func Test_RemoveMemberFromGroupWithInvalidResponse(t *testing.T) {
 	})
 
 	assert.EqualError(t, err, `remove member "mail" from azure group "mail@example.com": 200 OK: some response body`)
-}
-
-func newUuid() uuid.UUID {
-	id, _ := uuid.NewUUID()
-	return id
 }

--- a/pkg/db/api_key.go
+++ b/pkg/db/api_key.go
@@ -7,9 +7,13 @@ import (
 	"github.com/nais/console/pkg/sqlc"
 )
 
-func (d *database) CreateAPIKey(ctx context.Context, apiKey string, userID uuid.UUID) error {
+func (d *database) CreateAPIKey(ctx context.Context, apiKey string, serviceAccountID uuid.UUID) error {
 	return d.querier.CreateAPIKey(ctx, sqlc.CreateAPIKeyParams{
 		ApiKey: apiKey,
-		UserID: userID,
+		UserID: serviceAccountID,
 	})
+}
+
+func (d *database) RemoveApiKeysFromServiceAccount(ctx context.Context, serviceAccountID uuid.UUID) error {
+	return d.querier.RemoveApiKeysFromServiceAccount(ctx, serviceAccountID)
 }

--- a/pkg/db/audit_log.go
+++ b/pkg/db/audit_log.go
@@ -8,10 +8,6 @@ import (
 	"github.com/nais/console/pkg/sqlc"
 )
 
-type AuditLog struct {
-	*sqlc.AuditLog
-}
-
 func (d *database) GetAuditLogsForTeam(ctx context.Context, slug slug.Slug) ([]*AuditLog, error) {
 	rows, err := d.querier.GetAuditLogsForTeam(ctx, &slug)
 	if err != nil {
@@ -25,14 +21,14 @@ func (d *database) GetAuditLogsForTeam(ctx context.Context, slug slug.Slug) ([]*
 	return entries, nil
 }
 
-func (d *database) AddAuditLog(ctx context.Context, correlationID uuid.UUID, systemName sqlc.SystemName, actorEmail *string, targetTeamSlug *slug.Slug, targetUserEmail *string, action sqlc.AuditAction, message string) error {
+func (d *database) CreateAuditLogEntry(ctx context.Context, correlationID uuid.UUID, systemName sqlc.SystemName, actor *string, targetTeamSlug *slug.Slug, targetUser *string, action sqlc.AuditAction, message string) error {
 	return d.querier.CreateAuditLog(ctx, sqlc.CreateAuditLogParams{
-		CorrelationID:   correlationID,
-		ActorEmail:      nullString(actorEmail),
-		SystemName:      systemName,
-		TargetTeamSlug:  targetTeamSlug,
-		TargetUserEmail: nullString(targetUserEmail),
-		Action:          action,
-		Message:         message,
+		CorrelationID:  correlationID,
+		Actor:          nullString(actor),
+		SystemName:     systemName,
+		TargetTeamSlug: targetTeamSlug,
+		TargetUser:     nullString(targetUser),
+		Action:         action,
+		Message:        message,
 	})
 }

--- a/pkg/db/database.go
+++ b/pkg/db/database.go
@@ -1,7 +1,6 @@
 package db
 
 import (
-	"context"
 	"database/sql"
 	"errors"
 
@@ -10,68 +9,8 @@ import (
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
 	"github.com/golang-migrate/migrate/v4/source/iofs"
 	"github.com/google/uuid"
-	"github.com/nais/console/pkg/slug"
-	"github.com/nais/console/pkg/sqlc"
 	"github.com/nais/console/sqlc/schemas"
 )
-
-type database struct {
-	querier Querier
-}
-
-type TransactionFunc func(ctx context.Context, dbtx Database) error
-
-type Database interface {
-	AddAuditLog(ctx context.Context, correlationID uuid.UUID, systemName sqlc.SystemName, actorEmail *string, targetTeamSlug *slug.Slug, targetUserEmail *string, action sqlc.AuditAction, message string) error
-	AddUser(ctx context.Context, name, email string) (*User, error)
-	AddServiceAccount(ctx context.Context, name string) (*ServiceAccount, error)
-	GetServiceAccount(ctx context.Context, name string) (*ServiceAccount, error)
-	GetUserByID(ctx context.Context, ID uuid.UUID) (*User, error)
-	GetUserByEmail(ctx context.Context, email string) (*User, error)
-	GetUserByApiKey(ctx context.Context, APIKey string) (*User, error)
-	DeleteUser(ctx context.Context, userID uuid.UUID) error
-
-	GetUsersByEmail(ctx context.Context, email string) ([]*User, error)
-	GetUsers(ctx context.Context) ([]*User, error)
-	GetUserTeams(ctx context.Context, userID uuid.UUID) ([]*Team, error)
-
-	AddTeam(ctx context.Context, name string, slug slug.Slug, purpose *string, userID uuid.UUID) (*Team, error)
-	SetTeamMetadata(ctx context.Context, teamID uuid.UUID, metadata TeamMetadata) error
-	GetTeamMetadata(ctx context.Context, teamID uuid.UUID) (TeamMetadata, error)
-	UpdateTeam(ctx context.Context, teamID uuid.UUID, name, purpose *string) (*Team, error)
-	GetTeamByID(ctx context.Context, ID uuid.UUID) (*Team, error)
-	GetTeamBySlug(ctx context.Context, slug slug.Slug) (*Team, error)
-	GetTeams(ctx context.Context) ([]*Team, error)
-	GetTeamMembers(ctx context.Context, teamID uuid.UUID) ([]*User, error)
-	UserIsTeamOwner(ctx context.Context, userID, teamID uuid.UUID) (bool, error)
-	SetTeamMemberRole(ctx context.Context, userID uuid.UUID, teamID uuid.UUID, role sqlc.RoleName) error
-
-	GetAuditLogsForTeam(ctx context.Context, slug slug.Slug) ([]*AuditLog, error)
-
-	AssignGlobalRoleToUser(ctx context.Context, userID uuid.UUID, roleName sqlc.RoleName) error
-	RevokeGlobalRoleFromUser(ctx context.Context, userID uuid.UUID, roleName sqlc.RoleName) error
-	AssignTargetedRoleToUser(ctx context.Context, userID uuid.UUID, roleName sqlc.RoleName, targetID uuid.UUID) error
-
-	RemoveUserFromTeam(ctx context.Context, userID uuid.UUID, teamID uuid.UUID) error
-
-	CreateAPIKey(ctx context.Context, apiKey string, userID uuid.UUID) error
-
-	RemoveAllUserRoles(ctx context.Context, userID uuid.UUID) error
-	RemoveApiKeysFromUser(ctx context.Context, userID uuid.UUID) error
-
-	GetUserRoles(ctx context.Context, userID uuid.UUID) ([]*Role, error)
-
-	Transaction(ctx context.Context, fn TransactionFunc) error
-
-	LoadSystemState(ctx context.Context, systemName sqlc.SystemName, teamID uuid.UUID, state interface{}) error
-	SetSystemState(ctx context.Context, systemName sqlc.SystemName, teamID uuid.UUID, state interface{}) error
-
-	SetUserName(ctx context.Context, userID uuid.UUID, name string) (*User, error)
-
-	SetTeamReconcileErrorForSystem(ctx context.Context, correlationID uuid.UUID, teamID uuid.UUID, systemName sqlc.SystemName, err error) error
-	GetTeamReconcileErrors(ctx context.Context, teamID uuid.UUID) ([]*ReconcileError, error)
-	ClearTeamReconcileErrorForSystem(ctx context.Context, teamID uuid.UUID, systemName sqlc.SystemName) error
-}
 
 func NewDatabase(q Querier) Database {
 	return &database{querier: q}

--- a/pkg/db/mock_database.go
+++ b/pkg/db/mock_database.go
@@ -18,89 +18,6 @@ type MockDatabase struct {
 	mock.Mock
 }
 
-// AddAuditLog provides a mock function with given fields: ctx, correlationID, systemName, actorEmail, targetTeamSlug, targetUserEmail, action, message
-func (_m *MockDatabase) AddAuditLog(ctx context.Context, correlationID uuid.UUID, systemName sqlc.SystemName, actorEmail *string, targetTeamSlug *slug.Slug, targetUserEmail *string, action sqlc.AuditAction, message string) error {
-	ret := _m.Called(ctx, correlationID, systemName, actorEmail, targetTeamSlug, targetUserEmail, action, message)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID, sqlc.SystemName, *string, *slug.Slug, *string, sqlc.AuditAction, string) error); ok {
-		r0 = rf(ctx, correlationID, systemName, actorEmail, targetTeamSlug, targetUserEmail, action, message)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// AddServiceAccount provides a mock function with given fields: ctx, name
-func (_m *MockDatabase) AddServiceAccount(ctx context.Context, name string) (*ServiceAccount, error) {
-	ret := _m.Called(ctx, name)
-
-	var r0 *ServiceAccount
-	if rf, ok := ret.Get(0).(func(context.Context, string) *ServiceAccount); ok {
-		r0 = rf(ctx, name)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*ServiceAccount)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, name)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// AddTeam provides a mock function with given fields: ctx, name, _a2, purpose, userID
-func (_m *MockDatabase) AddTeam(ctx context.Context, name string, _a2 slug.Slug, purpose *string, userID uuid.UUID) (*Team, error) {
-	ret := _m.Called(ctx, name, _a2, purpose, userID)
-
-	var r0 *Team
-	if rf, ok := ret.Get(0).(func(context.Context, string, slug.Slug, *string, uuid.UUID) *Team); ok {
-		r0 = rf(ctx, name, _a2, purpose, userID)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*Team)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, string, slug.Slug, *string, uuid.UUID) error); ok {
-		r1 = rf(ctx, name, _a2, purpose, userID)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// AddUser provides a mock function with given fields: ctx, name, email
-func (_m *MockDatabase) AddUser(ctx context.Context, name string, email string) (*User, error) {
-	ret := _m.Called(ctx, name, email)
-
-	var r0 *User
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) *User); ok {
-		r0 = rf(ctx, name, email)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*User)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
-		r1 = rf(ctx, name, email)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // AssignGlobalRoleToUser provides a mock function with given fields: ctx, userID, roleName
 func (_m *MockDatabase) AssignGlobalRoleToUser(ctx context.Context, userID uuid.UUID, roleName sqlc.RoleName) error {
 	ret := _m.Called(ctx, userID, roleName)
@@ -143,13 +60,110 @@ func (_m *MockDatabase) ClearTeamReconcileErrorForSystem(ctx context.Context, te
 	return r0
 }
 
-// CreateAPIKey provides a mock function with given fields: ctx, apiKey, userID
-func (_m *MockDatabase) CreateAPIKey(ctx context.Context, apiKey string, userID uuid.UUID) error {
-	ret := _m.Called(ctx, apiKey, userID)
+// CreateAPIKey provides a mock function with given fields: ctx, apiKey, serviceAccountID
+func (_m *MockDatabase) CreateAPIKey(ctx context.Context, apiKey string, serviceAccountID uuid.UUID) error {
+	ret := _m.Called(ctx, apiKey, serviceAccountID)
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, string, uuid.UUID) error); ok {
-		r0 = rf(ctx, apiKey, userID)
+		r0 = rf(ctx, apiKey, serviceAccountID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// CreateAuditLogEntry provides a mock function with given fields: ctx, correlationID, systemName, actor, targetTeamSlug, targetUser, action, message
+func (_m *MockDatabase) CreateAuditLogEntry(ctx context.Context, correlationID uuid.UUID, systemName sqlc.SystemName, actor *string, targetTeamSlug *slug.Slug, targetUser *string, action sqlc.AuditAction, message string) error {
+	ret := _m.Called(ctx, correlationID, systemName, actor, targetTeamSlug, targetUser, action, message)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID, sqlc.SystemName, *string, *slug.Slug, *string, sqlc.AuditAction, string) error); ok {
+		r0 = rf(ctx, correlationID, systemName, actor, targetTeamSlug, targetUser, action, message)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// CreateServiceAccount provides a mock function with given fields: ctx, name
+func (_m *MockDatabase) CreateServiceAccount(ctx context.Context, name string) (*ServiceAccount, error) {
+	ret := _m.Called(ctx, name)
+
+	var r0 *ServiceAccount
+	if rf, ok := ret.Get(0).(func(context.Context, string) *ServiceAccount); ok {
+		r0 = rf(ctx, name)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ServiceAccount)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, name)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// CreateTeam provides a mock function with given fields: ctx, name, _a2, purpose
+func (_m *MockDatabase) CreateTeam(ctx context.Context, name string, _a2 slug.Slug, purpose *string) (*Team, error) {
+	ret := _m.Called(ctx, name, _a2, purpose)
+
+	var r0 *Team
+	if rf, ok := ret.Get(0).(func(context.Context, string, slug.Slug, *string) *Team); ok {
+		r0 = rf(ctx, name, _a2, purpose)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*Team)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string, slug.Slug, *string) error); ok {
+		r1 = rf(ctx, name, _a2, purpose)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// CreateUser provides a mock function with given fields: ctx, name, email, externalID
+func (_m *MockDatabase) CreateUser(ctx context.Context, name string, email string, externalID string) (*User, error) {
+	ret := _m.Called(ctx, name, email, externalID)
+
+	var r0 *User
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) *User); ok {
+		r0 = rf(ctx, name, email, externalID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*User)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
+		r1 = rf(ctx, name, email, externalID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DeleteServiceAccount provides a mock function with given fields: ctx, serviceAccountID
+func (_m *MockDatabase) DeleteServiceAccount(ctx context.Context, serviceAccountID uuid.UUID) error {
+	ret := _m.Called(ctx, serviceAccountID)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID) error); ok {
+		r0 = rf(ctx, serviceAccountID)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -194,8 +208,31 @@ func (_m *MockDatabase) GetAuditLogsForTeam(ctx context.Context, _a1 slug.Slug) 
 	return r0, r1
 }
 
-// GetServiceAccount provides a mock function with given fields: ctx, name
-func (_m *MockDatabase) GetServiceAccount(ctx context.Context, name string) (*ServiceAccount, error) {
+// GetServiceAccountByApiKey provides a mock function with given fields: ctx, APIKey
+func (_m *MockDatabase) GetServiceAccountByApiKey(ctx context.Context, APIKey string) (*ServiceAccount, error) {
+	ret := _m.Called(ctx, APIKey)
+
+	var r0 *ServiceAccount
+	if rf, ok := ret.Get(0).(func(context.Context, string) *ServiceAccount); ok {
+		r0 = rf(ctx, APIKey)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ServiceAccount)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, APIKey)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetServiceAccountByName provides a mock function with given fields: ctx, name
+func (_m *MockDatabase) GetServiceAccountByName(ctx context.Context, name string) (*ServiceAccount, error) {
 	ret := _m.Called(ctx, name)
 
 	var r0 *ServiceAccount
@@ -210,6 +247,29 @@ func (_m *MockDatabase) GetServiceAccount(ctx context.Context, name string) (*Se
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
 		r1 = rf(ctx, name)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetServiceAccounts provides a mock function with given fields: ctx
+func (_m *MockDatabase) GetServiceAccounts(ctx context.Context) ([]*ServiceAccount, error) {
+	ret := _m.Called(ctx)
+
+	var r0 []*ServiceAccount
+	if rf, ok := ret.Get(0).(func(context.Context) []*ServiceAccount); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*ServiceAccount)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -355,29 +415,6 @@ func (_m *MockDatabase) GetTeams(ctx context.Context) ([]*Team, error) {
 	return r0, r1
 }
 
-// GetUserByApiKey provides a mock function with given fields: ctx, APIKey
-func (_m *MockDatabase) GetUserByApiKey(ctx context.Context, APIKey string) (*User, error) {
-	ret := _m.Called(ctx, APIKey)
-
-	var r0 *User
-	if rf, ok := ret.Get(0).(func(context.Context, string) *User); ok {
-		r0 = rf(ctx, APIKey)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*User)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, APIKey)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // GetUserByEmail provides a mock function with given fields: ctx, email
 func (_m *MockDatabase) GetUserByEmail(ctx context.Context, email string) (*User, error) {
 	ret := _m.Called(ctx, email)
@@ -394,6 +431,29 @@ func (_m *MockDatabase) GetUserByEmail(ctx context.Context, email string) (*User
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
 		r1 = rf(ctx, email)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetUserByExternalID provides a mock function with given fields: ctx, externalID
+func (_m *MockDatabase) GetUserByExternalID(ctx context.Context, externalID string) (*User, error) {
+	ret := _m.Called(ctx, externalID)
+
+	var r0 *User
+	if rf, ok := ret.Get(0).(func(context.Context, string) *User); ok {
+		r0 = rf(ctx, externalID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*User)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, externalID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -493,29 +553,6 @@ func (_m *MockDatabase) GetUsers(ctx context.Context) ([]*User, error) {
 	return r0, r1
 }
 
-// GetUsersByEmail provides a mock function with given fields: ctx, email
-func (_m *MockDatabase) GetUsersByEmail(ctx context.Context, email string) ([]*User, error) {
-	ret := _m.Called(ctx, email)
-
-	var r0 []*User
-	if rf, ok := ret.Get(0).(func(context.Context, string) []*User); ok {
-		r0 = rf(ctx, email)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]*User)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, email)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // LoadSystemState provides a mock function with given fields: ctx, systemName, teamID, state
 func (_m *MockDatabase) LoadSystemState(ctx context.Context, systemName sqlc.SystemName, teamID uuid.UUID, state interface{}) error {
 	ret := _m.Called(ctx, systemName, teamID, state)
@@ -544,13 +581,13 @@ func (_m *MockDatabase) RemoveAllUserRoles(ctx context.Context, userID uuid.UUID
 	return r0
 }
 
-// RemoveApiKeysFromUser provides a mock function with given fields: ctx, userID
-func (_m *MockDatabase) RemoveApiKeysFromUser(ctx context.Context, userID uuid.UUID) error {
-	ret := _m.Called(ctx, userID)
+// RemoveApiKeysFromServiceAccount provides a mock function with given fields: ctx, serviceAccountID
+func (_m *MockDatabase) RemoveApiKeysFromServiceAccount(ctx context.Context, serviceAccountID uuid.UUID) error {
+	ret := _m.Called(ctx, serviceAccountID)
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID) error); ok {
-		r0 = rf(ctx, userID)
+		r0 = rf(ctx, serviceAccountID)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -642,35 +679,12 @@ func (_m *MockDatabase) SetTeamReconcileErrorForSystem(ctx context.Context, corr
 	return r0
 }
 
-// SetUserName provides a mock function with given fields: ctx, userID, name
-func (_m *MockDatabase) SetUserName(ctx context.Context, userID uuid.UUID, name string) (*User, error) {
-	ret := _m.Called(ctx, userID, name)
-
-	var r0 *User
-	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID, string) *User); ok {
-		r0 = rf(ctx, userID, name)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*User)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, uuid.UUID, string) error); ok {
-		r1 = rf(ctx, userID, name)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // Transaction provides a mock function with given fields: ctx, fn
-func (_m *MockDatabase) Transaction(ctx context.Context, fn TransactionFunc) error {
+func (_m *MockDatabase) Transaction(ctx context.Context, fn DatabaseTransactionFunc) error {
 	ret := _m.Called(ctx, fn)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, TransactionFunc) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, DatabaseTransactionFunc) error); ok {
 		r0 = rf(ctx, fn)
 	} else {
 		r0 = ret.Error(0)
@@ -695,6 +709,29 @@ func (_m *MockDatabase) UpdateTeam(ctx context.Context, teamID uuid.UUID, name *
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, uuid.UUID, *string, *string) error); ok {
 		r1 = rf(ctx, teamID, name, purpose)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// UpdateUser provides a mock function with given fields: ctx, userID, name, email, externalID
+func (_m *MockDatabase) UpdateUser(ctx context.Context, userID uuid.UUID, name string, email string, externalID string) (*User, error) {
+	ret := _m.Called(ctx, userID, name, email, externalID)
+
+	var r0 *User
+	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID, string, string, string) *User); ok {
+		r0 = rf(ctx, userID, name, email, externalID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*User)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, uuid.UUID, string, string, string) error); ok {
+		r1 = rf(ctx, userID, name, email, externalID)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/db/querier.go
+++ b/pkg/db/querier.go
@@ -8,19 +8,6 @@ import (
 	"github.com/nais/console/pkg/sqlc"
 )
 
-type QuerierTxFn func(querier Querier) error
-
-type Querier interface {
-	sqlc.Querier
-	Transaction(ctx context.Context, callback QuerierTxFn) error
-}
-
-type Queries struct {
-	*sqlc.Queries
-	connPool *pgxpool.Pool
-	tx       pgx.Tx
-}
-
 func Wrap(q *sqlc.Queries, connPool *pgxpool.Pool) Querier {
 	return &Queries{
 		Queries:  q,
@@ -28,7 +15,7 @@ func Wrap(q *sqlc.Queries, connPool *pgxpool.Pool) Querier {
 	}
 }
 
-func (q *Queries) Transaction(ctx context.Context, callback QuerierTxFn) error {
+func (q *Queries) Transaction(ctx context.Context, callback QuerierTransactionFunc) error {
 	querier, err := q.begin(ctx)
 	if err != nil {
 		return err

--- a/pkg/db/reconcile_errors.go
+++ b/pkg/db/reconcile_errors.go
@@ -7,10 +7,6 @@ import (
 	"github.com/nais/console/pkg/sqlc"
 )
 
-type ReconcileError struct {
-	*sqlc.ReconcileError
-}
-
 func (d *database) SetTeamReconcileErrorForSystem(ctx context.Context, correlationID uuid.UUID, teamID uuid.UUID, systemName sqlc.SystemName, err error) error {
 	return d.querier.SetTeamReconcileErrorForSystem(ctx, sqlc.SetTeamReconcileErrorForSystemParams{
 		CorrelationID: correlationID,

--- a/pkg/db/transactions.go
+++ b/pkg/db/transactions.go
@@ -2,7 +2,7 @@ package db
 
 import "context"
 
-func (d *database) Transaction(ctx context.Context, fn TransactionFunc) error {
+func (d *database) Transaction(ctx context.Context, fn DatabaseTransactionFunc) error {
 	return d.querier.Transaction(ctx, func(querier Querier) error {
 		return fn(ctx, NewDatabase(querier))
 	})

--- a/pkg/db/types.go
+++ b/pkg/db/types.go
@@ -1,0 +1,136 @@
+package db
+
+import (
+	"context"
+
+	"github.com/nais/console/pkg/slug"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/nais/console/pkg/sqlc"
+)
+
+type (
+	QuerierTransactionFunc  func(querier Querier) error
+	DatabaseTransactionFunc func(ctx context.Context, dbtx Database) error
+)
+
+type AuthenticatedUser interface {
+	GetID() uuid.UUID
+	Identity() string
+	IsServiceAccount() bool
+}
+
+type AuditLog struct {
+	*sqlc.AuditLog
+}
+
+type ReconcileError struct {
+	*sqlc.ReconcileError
+}
+
+type Role struct {
+	*sqlc.UserRole
+	Name           sqlc.RoleName
+	Authorizations []sqlc.AuthzName
+}
+
+type ServiceAccount struct {
+	ID   uuid.UUID
+	Name string
+}
+
+type TeamMetadata map[string]string
+
+type Team struct {
+	*sqlc.Team
+}
+
+type User struct {
+	ID         uuid.UUID
+	Email      string
+	ExternalID string
+	Name       string
+}
+
+type Querier interface {
+	sqlc.Querier
+	Transaction(ctx context.Context, callback QuerierTransactionFunc) error
+}
+
+type Queries struct {
+	*sqlc.Queries
+	connPool *pgxpool.Pool
+	tx       pgx.Tx
+}
+
+type database struct {
+	querier Querier
+}
+
+type Database interface {
+	CreateAuditLogEntry(ctx context.Context, correlationID uuid.UUID, systemName sqlc.SystemName, actor *string, targetTeamSlug *slug.Slug, targetUser *string, action sqlc.AuditAction, message string) error
+	CreateUser(ctx context.Context, name, email, externalID string) (*User, error)
+	CreateServiceAccount(ctx context.Context, name string) (*ServiceAccount, error)
+	GetServiceAccountByName(ctx context.Context, name string) (*ServiceAccount, error)
+	GetUserByID(ctx context.Context, ID uuid.UUID) (*User, error)
+	GetUserByEmail(ctx context.Context, email string) (*User, error)
+	GetServiceAccountByApiKey(ctx context.Context, APIKey string) (*ServiceAccount, error)
+	DeleteUser(ctx context.Context, userID uuid.UUID) error
+	GetUsers(ctx context.Context) ([]*User, error)
+	GetUserTeams(ctx context.Context, userID uuid.UUID) ([]*Team, error)
+	CreateTeam(ctx context.Context, name string, slug slug.Slug, purpose *string) (*Team, error)
+	SetTeamMetadata(ctx context.Context, teamID uuid.UUID, metadata TeamMetadata) error
+	GetTeamMetadata(ctx context.Context, teamID uuid.UUID) (TeamMetadata, error)
+	UpdateTeam(ctx context.Context, teamID uuid.UUID, name, purpose *string) (*Team, error)
+	GetTeamByID(ctx context.Context, ID uuid.UUID) (*Team, error)
+	GetTeamBySlug(ctx context.Context, slug slug.Slug) (*Team, error)
+	GetTeams(ctx context.Context) ([]*Team, error)
+	GetTeamMembers(ctx context.Context, teamID uuid.UUID) ([]*User, error)
+	UserIsTeamOwner(ctx context.Context, userID, teamID uuid.UUID) (bool, error)
+	SetTeamMemberRole(ctx context.Context, userID uuid.UUID, teamID uuid.UUID, role sqlc.RoleName) error
+	GetAuditLogsForTeam(ctx context.Context, slug slug.Slug) ([]*AuditLog, error)
+	AssignGlobalRoleToUser(ctx context.Context, userID uuid.UUID, roleName sqlc.RoleName) error
+	RevokeGlobalRoleFromUser(ctx context.Context, userID uuid.UUID, roleName sqlc.RoleName) error
+	AssignTargetedRoleToUser(ctx context.Context, userID uuid.UUID, roleName sqlc.RoleName, targetID uuid.UUID) error
+	RemoveUserFromTeam(ctx context.Context, userID uuid.UUID, teamID uuid.UUID) error
+	CreateAPIKey(ctx context.Context, apiKey string, serviceAccountID uuid.UUID) error
+	RemoveAllUserRoles(ctx context.Context, userID uuid.UUID) error
+	RemoveApiKeysFromServiceAccount(ctx context.Context, serviceAccountID uuid.UUID) error
+	GetUserRoles(ctx context.Context, userID uuid.UUID) ([]*Role, error)
+	Transaction(ctx context.Context, fn DatabaseTransactionFunc) error
+	LoadSystemState(ctx context.Context, systemName sqlc.SystemName, teamID uuid.UUID, state interface{}) error
+	SetSystemState(ctx context.Context, systemName sqlc.SystemName, teamID uuid.UUID, state interface{}) error
+	UpdateUser(ctx context.Context, userID uuid.UUID, name, email, externalID string) (*User, error)
+	SetTeamReconcileErrorForSystem(ctx context.Context, correlationID uuid.UUID, teamID uuid.UUID, systemName sqlc.SystemName, err error) error
+	GetTeamReconcileErrors(ctx context.Context, teamID uuid.UUID) ([]*ReconcileError, error)
+	ClearTeamReconcileErrorForSystem(ctx context.Context, teamID uuid.UUID, systemName sqlc.SystemName) error
+	GetServiceAccounts(ctx context.Context) ([]*ServiceAccount, error)
+	DeleteServiceAccount(ctx context.Context, serviceAccountID uuid.UUID) error
+	GetUserByExternalID(ctx context.Context, externalID string) (*User, error)
+}
+
+func (u User) GetID() uuid.UUID {
+	return u.ID
+}
+
+func (u User) Identity() string {
+	return u.Email
+}
+
+func (u User) IsServiceAccount() bool {
+	return false
+}
+
+func (s ServiceAccount) GetID() uuid.UUID {
+	return s.ID
+}
+
+func (s ServiceAccount) Identity() string {
+	return s.Name
+}
+
+func (s ServiceAccount) IsServiceAccount() bool {
+	return true
+}

--- a/pkg/directives/auth.go
+++ b/pkg/directives/auth.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/nais/console/pkg/db"
-
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/nais/console/pkg/authz"
 )
@@ -13,16 +11,11 @@ import (
 type AuthDirective func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error)
 
 // Auth Make sure there is an authenticated user making this request.
-func Auth(database db.Database) AuthDirective {
+func Auth() AuthDirective {
 	return func(ctx context.Context, obj interface{}, next graphql.Resolver) (interface{}, error) {
 		actor := authz.ActorFromContext(ctx)
 		if !actor.Authenticated() {
 			return nil, fmt.Errorf("this endpoint requires an authenticated user")
-		}
-
-		_, err := database.GetUserByID(ctx, actor.User.ID)
-		if err != nil {
-			return nil, fmt.Errorf("user in context does not exist in database: %w", err)
 		}
 
 		return next(ctx)

--- a/pkg/directives/auth_test.go
+++ b/pkg/directives/auth_test.go
@@ -2,15 +2,10 @@ package directives_test
 
 import (
 	"context"
-	"errors"
 	"testing"
 
-	"github.com/google/uuid"
-	"github.com/nais/console/pkg/authz"
-	"github.com/nais/console/pkg/db"
 	"github.com/nais/console/pkg/directives"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 func TestAuth(t *testing.T) {
@@ -18,32 +13,12 @@ func TestAuth(t *testing.T) {
 	var nextHandler func(ctx context.Context) (res interface{}, err error)
 
 	t.Run("No user in context", func(t *testing.T) {
-		database := db.NewMockDatabase(t)
-		auth := directives.Auth(database)
+		auth := directives.Auth()
 
 		nextHandler = func(ctx context.Context) (res interface{}, err error) {
 			panic("Should not be executed")
 		}
 		_, err := auth(context.Background(), obj, nextHandler)
 		assert.EqualError(t, err, "this endpoint requires an authenticated user")
-	})
-
-	t.Run("Unknown user in context", func(t *testing.T) {
-		database := db.NewMockDatabase(t)
-		auth := directives.Auth(database)
-
-		userID := uuid.New()
-		user := &db.User{ID: userID}
-
-		database.
-			On("GetUserByID", mock.Anything, userID).
-			Return(nil, errors.New("record not found")).
-			Once()
-
-		nextHandler = func(ctx context.Context) (res interface{}, err error) {
-			panic("Should not be executed")
-		}
-		_, err := auth(authz.ContextWithActor(context.Background(), user, []*db.Role{}), obj, nextHandler)
-		assert.EqualError(t, err, "user in context does not exist in database: record not found")
 	})
 }

--- a/pkg/graph/auditlogs.go
+++ b/pkg/graph/auditlogs.go
@@ -10,14 +10,14 @@ import (
 	"github.com/nais/console/pkg/graph/generated"
 )
 
-// ActorEmail is the resolver for the actorEmail field.
-func (r *auditLogResolver) ActorEmail(ctx context.Context, obj *db.AuditLog) (*string, error) {
-	return db.NullStringToStringP(obj.ActorEmail), nil
+// Actor is the resolver for the actor field.
+func (r *auditLogResolver) Actor(ctx context.Context, obj *db.AuditLog) (*string, error) {
+	return db.NullStringToStringP(obj.Actor), nil
 }
 
-// TargetUserEmail is the resolver for the targetUserEmail field.
-func (r *auditLogResolver) TargetUserEmail(ctx context.Context, obj *db.AuditLog) (*string, error) {
-	return db.NullStringToStringP(obj.TargetUserEmail), nil
+// TargetUser is the resolver for the targetUser field.
+func (r *auditLogResolver) TargetUser(ctx context.Context, obj *db.AuditLog) (*string, error) {
+	return db.NullStringToStringP(obj.TargetUser), nil
 }
 
 // AuditLog returns generated.AuditLogResolver implementation.

--- a/pkg/graph/authentication.go
+++ b/pkg/graph/authentication.go
@@ -1,0 +1,16 @@
+package graph
+
+// This file will be automatically regenerated based on the schema, any resolver implementations
+// will be copied through when generating and any unknown code will be moved to the end.
+
+import (
+	"context"
+
+	"github.com/nais/console/pkg/authz"
+	"github.com/nais/console/pkg/db"
+)
+
+// Me is the resolver for the me field.
+func (r *queryResolver) Me(ctx context.Context) (db.AuthenticatedUser, error) {
+	return authz.ActorFromContext(ctx).User, nil
+}

--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -76,6 +76,14 @@ type TeamMember struct {
 	Role TeamRole `json:"role"`
 }
 
+// Team membership type.
+type TeamMembership struct {
+	// Team instance.
+	Team *db.Team `json:"team"`
+	// The role that the member has in the team.
+	Role TeamRole `json:"role"`
+}
+
 // Team sync type.
 type TeamSync struct {
 	// The team that will be synced.
@@ -90,14 +98,6 @@ type UpdateTeamInput struct {
 	Name *string `json:"name"`
 	// Team purpose. Set to an empty string to remove the existing team purpose.
 	Purpose *string `json:"purpose"`
-}
-
-// User team.
-type UserTeam struct {
-	// Team instance.
-	Team *db.Team `json:"team"`
-	// The role that the user has in the team.
-	Role TeamRole `json:"role"`
 }
 
 // Available team roles.

--- a/pkg/graph/roles.go
+++ b/pkg/graph/roles.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/nais/console/pkg/auditlogger"
 	"github.com/nais/console/pkg/authz"
+	"github.com/nais/console/pkg/console"
 	"github.com/nais/console/pkg/db"
 	"github.com/nais/console/pkg/graph/generated"
 	"github.com/nais/console/pkg/sqlc"
@@ -38,9 +39,9 @@ func (r *mutationResolver) AssignGlobalRoleToUser(ctx context.Context, role sqlc
 	}
 
 	fields := auditlogger.Fields{
-		Action:          sqlc.AuditActionGraphqlApiRolesAssignGlobalRole,
-		ActorEmail:      &actor.User.Email,
-		TargetUserEmail: &user.Email,
+		Action:     sqlc.AuditActionGraphqlApiRolesAssignGlobalRole,
+		Actor:      console.Strp(actor.User.Identity()),
+		TargetUser: &user.Email,
 	}
 	r.auditLogger.Logf(ctx, fields, "Assign global role %q to user", role)
 
@@ -70,9 +71,9 @@ func (r *mutationResolver) RevokeGlobalRoleFromUser(ctx context.Context, role sq
 	}
 
 	fields := auditlogger.Fields{
-		Action:          sqlc.AuditActionGraphqlApiRolesRevokeGlobalRole,
-		ActorEmail:      &actor.User.Email,
-		TargetUserEmail: &user.Email,
+		Action:     sqlc.AuditActionGraphqlApiRolesRevokeGlobalRole,
+		Actor:      console.Strp(actor.User.Identity()),
+		TargetUser: &user.Email,
 	}
 	r.auditLogger.Logf(ctx, fields, "Revoke global role %q from user", role)
 

--- a/pkg/graph/serviceAccounts.go
+++ b/pkg/graph/serviceAccounts.go
@@ -1,0 +1,31 @@
+package graph
+
+// This file will be automatically regenerated based on the schema, any resolver implementations
+// will be copied through when generating and any unknown code will be moved to the end.
+
+import (
+	"context"
+
+	"github.com/nais/console/pkg/authz"
+	"github.com/nais/console/pkg/db"
+	"github.com/nais/console/pkg/graph/generated"
+	"github.com/nais/console/pkg/sqlc"
+)
+
+// Roles is the resolver for the roles field.
+func (r *serviceAccountResolver) Roles(ctx context.Context, obj *db.ServiceAccount) ([]*db.Role, error) {
+	actor := authz.ActorFromContext(ctx)
+	err := authz.RequireAuthorizationOrTargetMatch(actor, sqlc.AuthzNameUsersUpdate, obj.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	return r.database.GetUserRoles(ctx, obj.ID)
+}
+
+// ServiceAccount returns generated.ServiceAccountResolver implementation.
+func (r *Resolver) ServiceAccount() generated.ServiceAccountResolver {
+	return &serviceAccountResolver{r}
+}
+
+type serviceAccountResolver struct{ *Resolver }

--- a/pkg/graph/users.go
+++ b/pkg/graph/users.go
@@ -47,13 +47,8 @@ func (r *queryResolver) UserByEmail(ctx context.Context, email string) (*db.User
 	return r.database.GetUserByEmail(ctx, email)
 }
 
-// Me is the resolver for the me field.
-func (r *queryResolver) Me(ctx context.Context) (*db.User, error) {
-	return authz.ActorFromContext(ctx).User, nil
-}
-
 // Teams is the resolver for the teams field.
-func (r *userResolver) Teams(ctx context.Context, obj *db.User) ([]*model.UserTeam, error) {
+func (r *userResolver) Teams(ctx context.Context, obj *db.User) ([]*model.TeamMembership, error) {
 	actor := authz.ActorFromContext(ctx)
 	err := authz.RequireGlobalAuthorization(actor, sqlc.AuthzNameTeamsList)
 	if err != nil {
@@ -65,7 +60,7 @@ func (r *userResolver) Teams(ctx context.Context, obj *db.User) ([]*model.UserTe
 		return nil, err
 	}
 
-	userTeams := make([]*model.UserTeam, 0, len(teams))
+	userTeams := make([]*model.TeamMembership, 0, len(teams))
 	for _, team := range teams {
 		isOwner, err := r.database.UserIsTeamOwner(ctx, obj.ID, team.ID)
 		if err != nil {
@@ -77,7 +72,7 @@ func (r *userResolver) Teams(ctx context.Context, obj *db.User) ([]*model.UserTe
 			role = model.TeamRoleOwner
 		}
 
-		userTeams = append(userTeams, &model.UserTeam{
+		userTeams = append(userTeams, &model.TeamMembership{
 			Team: team,
 			Role: role,
 		})

--- a/pkg/legacy/importer.go
+++ b/pkg/legacy/importer.go
@@ -63,8 +63,9 @@ func dbUsers(members []*azureclient.Member) []*db.User {
 	users := make([]*db.User, 0, len(members))
 	for _, member := range members {
 		users = append(users, &db.User{
-			Email: member.Mail,
-			Name:  member.Name(),
+			Email:      member.Mail,
+			ExternalID: member.Mail, // We don't have the external ID at this point, use the email instead and the user sync will automatically fix it
+			Name:       member.Name(),
 		})
 	}
 	return users

--- a/pkg/reconcilers/azure/group/reconciler.go
+++ b/pkg/reconcilers/azure/group/reconciler.go
@@ -127,10 +127,10 @@ func (r *azureGroupReconciler) connectUsers(ctx context.Context, grp *azureclien
 		}
 
 		fields := auditlogger.Fields{
-			Action:          sqlc.AuditActionAzureGroupDeleteMember,
-			CorrelationID:   input.CorrelationID,
-			TargetTeamSlug:  &input.Team.Slug,
-			TargetUserEmail: &remoteEmail,
+			Action:         sqlc.AuditActionAzureGroupDeleteMember,
+			CorrelationID:  input.CorrelationID,
+			TargetTeamSlug: &input.Team.Slug,
+			TargetUser:     &remoteEmail,
 		}
 		r.auditLogger.Logf(ctx, fields, "removed member %q from Azure group %q", remoteEmail, grp.MailNickname)
 	}
@@ -149,10 +149,10 @@ func (r *azureGroupReconciler) connectUsers(ctx context.Context, grp *azureclien
 		}
 
 		fields := auditlogger.Fields{
-			Action:          sqlc.AuditActionAzureGroupAddMember,
-			CorrelationID:   input.CorrelationID,
-			TargetTeamSlug:  &input.Team.Slug,
-			TargetUserEmail: &consoleUser.Email,
+			Action:         sqlc.AuditActionAzureGroupAddMember,
+			CorrelationID:  input.CorrelationID,
+			TargetTeamSlug: &input.Team.Slug,
+			TargetUser:     &consoleUser.Email,
 		}
 		r.auditLogger.Logf(ctx, fields, "added member %q to Azure group %q", consoleUser.Email, grp.MailNickname)
 	}

--- a/pkg/reconcilers/azure/group/reconciler_test.go
+++ b/pkg/reconcilers/azure/group/reconciler_test.go
@@ -127,7 +127,7 @@ func TestAzureReconciler_Reconcile(t *testing.T) {
 				return f.Action == sqlc.AuditActionAzureGroupDeleteMember &&
 					f.CorrelationID == correlationID &&
 					f.TargetTeamSlug.String() == teamSlug.String() &&
-					*f.TargetUserEmail == removeMember.Mail
+					*f.TargetUser == removeMember.Mail
 			}), mock.Anything, removeMember.Mail, group.MailNickname).
 			Return(nil).
 			Once()
@@ -136,7 +136,7 @@ func TestAzureReconciler_Reconcile(t *testing.T) {
 				return f.Action == sqlc.AuditActionAzureGroupAddMember &&
 					f.CorrelationID == correlationID &&
 					f.TargetTeamSlug.String() == teamSlug.String() &&
-					*f.TargetUserEmail == addUser.Email
+					*f.TargetUser == addUser.Email
 			}), mock.Anything, addUser.Email, group.MailNickname).
 			Return(nil).
 			Once()
@@ -280,7 +280,7 @@ func TestAzureReconciler_Reconcile(t *testing.T) {
 				return f.Action == sqlc.AuditActionAzureGroupDeleteMember &&
 					f.CorrelationID == correlationID &&
 					f.TargetTeamSlug.String() == teamSlug.String() &&
-					*f.TargetUserEmail == removeMember.Mail
+					*f.TargetUser == removeMember.Mail
 			}), mock.Anything, removeMember.Mail, group.MailNickname).
 			Return(nil).
 			Once()

--- a/pkg/reconcilers/github/team/reconciler.go
+++ b/pkg/reconcilers/github/team/reconciler.go
@@ -180,10 +180,10 @@ func (r *githubTeamReconciler) connectUsers(ctx context.Context, githubTeam *git
 		}
 
 		fields := auditlogger.Fields{
-			Action:          sqlc.AuditActionGithubTeamAddMember,
-			CorrelationID:   input.CorrelationID,
-			TargetTeamSlug:  &input.Team.Slug,
-			TargetUserEmail: &consoleUser.Email,
+			Action:         sqlc.AuditActionGithubTeamAddMember,
+			CorrelationID:  input.CorrelationID,
+			TargetTeamSlug: &input.Team.Slug,
+			TargetUser:     &consoleUser.Email,
 		}
 		r.auditLogger.Logf(ctx, fields, "added member %q to GitHub team %q", username, *githubTeam.Slug)
 	}

--- a/pkg/reconcilers/google/workspace_admin/reconciler.go
+++ b/pkg/reconcilers/google/workspace_admin/reconciler.go
@@ -144,10 +144,10 @@ func (r *googleWorkspaceAdminReconciler) connectUsers(ctx context.Context, grp *
 		}
 
 		fields := auditlogger.Fields{
-			Action:          sqlc.AuditActionGoogleWorkspaceAdminDeleteMember,
-			CorrelationID:   input.CorrelationID,
-			TargetTeamSlug:  &input.Team.Slug,
-			TargetUserEmail: &remoteMemberEmail,
+			Action:         sqlc.AuditActionGoogleWorkspaceAdminDeleteMember,
+			CorrelationID:  input.CorrelationID,
+			TargetTeamSlug: &input.Team.Slug,
+			TargetUser:     &remoteMemberEmail,
 		}
 		r.auditLogger.Logf(ctx, fields, "deleted member %q from Google Directory group %q", member.Email, grp.Email)
 	}
@@ -163,10 +163,10 @@ func (r *googleWorkspaceAdminReconciler) connectUsers(ctx context.Context, grp *
 			continue
 		}
 		fields := auditlogger.Fields{
-			Action:          sqlc.AuditActionGoogleWorkspaceAdminAddMember,
-			CorrelationID:   input.CorrelationID,
-			TargetTeamSlug:  &input.Team.Slug,
-			TargetUserEmail: &user.Email,
+			Action:         sqlc.AuditActionGoogleWorkspaceAdminAddMember,
+			CorrelationID:  input.CorrelationID,
+			TargetTeamSlug: &input.Team.Slug,
+			TargetUser:     &user.Email,
 		}
 		r.auditLogger.Logf(ctx, fields, "added member %q to Google Directory group %q", member.Email, grp.Email)
 	}

--- a/pkg/sqlc/api_keys.sql.go
+++ b/pkg/sqlc/api_keys.sql.go
@@ -12,7 +12,8 @@ import (
 )
 
 const createAPIKey = `-- name: CreateAPIKey :exec
-INSERT INTO api_keys (api_key, user_id) VALUES ($1, $2)
+INSERT INTO api_keys (api_key, user_id)
+VALUES ($1, $2)
 `
 
 type CreateAPIKeyParams struct {
@@ -25,11 +26,12 @@ func (q *Queries) CreateAPIKey(ctx context.Context, arg CreateAPIKeyParams) erro
 	return err
 }
 
-const removeApiKeysFromUser = `-- name: RemoveApiKeysFromUser :exec
-DELETE FROM api_keys WHERE user_id = $1
+const removeApiKeysFromServiceAccount = `-- name: RemoveApiKeysFromServiceAccount :exec
+DELETE FROM api_keys
+WHERE user_id = $1
 `
 
-func (q *Queries) RemoveApiKeysFromUser(ctx context.Context, userID uuid.UUID) error {
-	_, err := q.db.Exec(ctx, removeApiKeysFromUser, userID)
+func (q *Queries) RemoveApiKeysFromServiceAccount(ctx context.Context, userID uuid.UUID) error {
+	_, err := q.db.Exec(ctx, removeApiKeysFromServiceAccount, userID)
 	return err
 }

--- a/pkg/sqlc/audit_logs.sql.go
+++ b/pkg/sqlc/audit_logs.sql.go
@@ -14,26 +14,26 @@ import (
 )
 
 const createAuditLog = `-- name: CreateAuditLog :exec
-INSERT INTO audit_logs (correlation_id, actor_email, system_name, target_user_email, target_team_slug, action, message)
+INSERT INTO audit_logs (correlation_id, actor, system_name, target_user, target_team_slug, action, message)
 VALUES ($1, $2, $3, $4, $5, $6, $7)
 `
 
 type CreateAuditLogParams struct {
-	CorrelationID   uuid.UUID
-	ActorEmail      sql.NullString
-	SystemName      SystemName
-	TargetUserEmail sql.NullString
-	TargetTeamSlug  *slug.Slug
-	Action          AuditAction
-	Message         string
+	CorrelationID  uuid.UUID
+	Actor          sql.NullString
+	SystemName     SystemName
+	TargetUser     sql.NullString
+	TargetTeamSlug *slug.Slug
+	Action         AuditAction
+	Message        string
 }
 
 func (q *Queries) CreateAuditLog(ctx context.Context, arg CreateAuditLogParams) error {
 	_, err := q.db.Exec(ctx, createAuditLog,
 		arg.CorrelationID,
-		arg.ActorEmail,
+		arg.Actor,
 		arg.SystemName,
-		arg.TargetUserEmail,
+		arg.TargetUser,
 		arg.TargetTeamSlug,
 		arg.Action,
 		arg.Message,
@@ -42,7 +42,10 @@ func (q *Queries) CreateAuditLog(ctx context.Context, arg CreateAuditLogParams) 
 }
 
 const getAuditLogsForTeam = `-- name: GetAuditLogsForTeam :many
-SELECT id, created_at, correlation_id, system_name, actor_email, target_user_email, target_team_slug, action, message FROM audit_logs WHERE target_team_slug = $1 ORDER BY created_at DESC LIMIT 100
+SELECT id, created_at, correlation_id, system_name, actor, target_user, target_team_slug, action, message FROM audit_logs
+WHERE target_team_slug = $1
+ORDER BY created_at DESC
+LIMIT 100
 `
 
 func (q *Queries) GetAuditLogsForTeam(ctx context.Context, targetTeamSlug *slug.Slug) ([]*AuditLog, error) {
@@ -59,8 +62,8 @@ func (q *Queries) GetAuditLogsForTeam(ctx context.Context, targetTeamSlug *slug.
 			&i.CreatedAt,
 			&i.CorrelationID,
 			&i.SystemName,
-			&i.ActorEmail,
-			&i.TargetUserEmail,
+			&i.Actor,
+			&i.TargetUser,
 			&i.TargetTeamSlug,
 			&i.Action,
 			&i.Message,

--- a/pkg/sqlc/models.go
+++ b/pkg/sqlc/models.go
@@ -460,15 +460,15 @@ type ApiKey struct {
 }
 
 type AuditLog struct {
-	ID              uuid.UUID
-	CreatedAt       time.Time
-	CorrelationID   uuid.UUID
-	SystemName      SystemName
-	ActorEmail      sql.NullString
-	TargetUserEmail sql.NullString
-	TargetTeamSlug  *slug.Slug
-	Action          AuditAction
-	Message         string
+	ID             uuid.UUID
+	CreatedAt      time.Time
+	CorrelationID  uuid.UUID
+	SystemName     SystemName
+	Actor          sql.NullString
+	TargetUser     sql.NullString
+	TargetTeamSlug *slug.Slug
+	Action         AuditAction
+	Message        string
 }
 
 type ReconcileError struct {
@@ -509,6 +509,7 @@ type User struct {
 	Email          sql.NullString
 	Name           string
 	ServiceAccount bool
+	ExternalID     sql.NullString
 }
 
 type UserRole struct {

--- a/pkg/sqlc/querier.go
+++ b/pkg/sqlc/querier.go
@@ -20,10 +20,13 @@ type Querier interface {
 	CreateServiceAccount(ctx context.Context, name string) (*User, error)
 	CreateTeam(ctx context.Context, arg CreateTeamParams) (*Team, error)
 	CreateUser(ctx context.Context, arg CreateUserParams) (*User, error)
+	DeleteServiceAccount(ctx context.Context, id uuid.UUID) error
 	DeleteUser(ctx context.Context, id uuid.UUID) error
 	GetAuditLogsForTeam(ctx context.Context, targetTeamSlug *slug.Slug) ([]*AuditLog, error)
 	GetRoleAuthorizations(ctx context.Context, roleName RoleName) ([]AuthzName, error)
-	GetServiceAccount(ctx context.Context, name string) (*User, error)
+	GetServiceAccountByApiKey(ctx context.Context, apiKey string) (*User, error)
+	GetServiceAccountByName(ctx context.Context, name string) (*User, error)
+	GetServiceAccounts(ctx context.Context) ([]*User, error)
 	GetTeamByID(ctx context.Context, id uuid.UUID) (*Team, error)
 	GetTeamBySlug(ctx context.Context, slug slug.Slug) (*Team, error)
 	GetTeamMembers(ctx context.Context, teamID uuid.UUID) ([]*User, error)
@@ -31,23 +34,22 @@ type Querier interface {
 	GetTeamReconcileErrors(ctx context.Context, teamID uuid.UUID) ([]*ReconcileError, error)
 	GetTeamSystemState(ctx context.Context, arg GetTeamSystemStateParams) (*SystemState, error)
 	GetTeams(ctx context.Context) ([]*Team, error)
-	GetUserByApiKey(ctx context.Context, apiKey string) (*User, error)
 	GetUserByEmail(ctx context.Context, email string) (*User, error)
+	GetUserByExternalID(ctx context.Context, externalID string) (*User, error)
 	GetUserByID(ctx context.Context, id uuid.UUID) (*User, error)
 	GetUserRoles(ctx context.Context, userID uuid.UUID) ([]*UserRole, error)
 	GetUserTeams(ctx context.Context, userID uuid.UUID) ([]*Team, error)
 	GetUsers(ctx context.Context) ([]*User, error)
-	GetUsersByEmail(ctx context.Context, email string) ([]*User, error)
 	RemoveAllUserRoles(ctx context.Context, userID uuid.UUID) error
-	RemoveApiKeysFromUser(ctx context.Context, userID uuid.UUID) error
+	RemoveApiKeysFromServiceAccount(ctx context.Context, userID uuid.UUID) error
 	RemoveGlobalUserRole(ctx context.Context, arg RemoveGlobalUserRoleParams) error
 	RevokeGlobalRoleFromUser(ctx context.Context, arg RevokeGlobalRoleFromUserParams) error
 	RevokeTargetedRoleFromUser(ctx context.Context, arg RevokeTargetedRoleFromUserParams) error
 	SetTeamMetadata(ctx context.Context, arg SetTeamMetadataParams) error
 	SetTeamReconcileErrorForSystem(ctx context.Context, arg SetTeamReconcileErrorForSystemParams) error
 	SetTeamSystemState(ctx context.Context, arg SetTeamSystemStateParams) error
-	SetUserName(ctx context.Context, arg SetUserNameParams) (*User, error)
 	UpdateTeam(ctx context.Context, arg UpdateTeamParams) (*Team, error)
+	UpdateUser(ctx context.Context, arg UpdateUserParams) (*User, error)
 }
 
 var _ Querier = (*Queries)(nil)

--- a/pkg/sqlc/reconcile_errors.sql.go
+++ b/pkg/sqlc/reconcile_errors.sql.go
@@ -12,7 +12,8 @@ import (
 )
 
 const clearTeamReconcileErrorForSystem = `-- name: ClearTeamReconcileErrorForSystem :exec
-DELETE FROM reconcile_errors WHERE team_id = $1 AND system_name = $2
+DELETE FROM reconcile_errors
+WHERE team_id = $1 AND system_name = $2
 `
 
 type ClearTeamReconcileErrorForSystemParams struct {
@@ -26,7 +27,9 @@ func (q *Queries) ClearTeamReconcileErrorForSystem(ctx context.Context, arg Clea
 }
 
 const getTeamReconcileErrors = `-- name: GetTeamReconcileErrors :many
-SELECT id, correlation_id, team_id, system_name, created_at, error_message FROM reconcile_errors WHERE team_id = $1 ORDER BY created_at DESC
+SELECT id, correlation_id, team_id, system_name, created_at, error_message FROM reconcile_errors
+WHERE team_id = $1
+ORDER BY created_at DESC
 `
 
 func (q *Queries) GetTeamReconcileErrors(ctx context.Context, teamID uuid.UUID) ([]*ReconcileError, error) {

--- a/pkg/sqlc/system_states.sql.go
+++ b/pkg/sqlc/system_states.sql.go
@@ -13,7 +13,8 @@ import (
 )
 
 const getTeamSystemState = `-- name: GetTeamSystemState :one
-SELECT system_name, team_id, state FROM system_states WHERE system_name = $1 AND team_id = $2 LIMIT 1
+SELECT system_name, team_id, state FROM system_states
+WHERE system_name = $1 AND team_id = $2
 `
 
 type GetTeamSystemStateParams struct {
@@ -29,7 +30,10 @@ func (q *Queries) GetTeamSystemState(ctx context.Context, arg GetTeamSystemState
 }
 
 const setTeamSystemState = `-- name: SetTeamSystemState :exec
-INSERT INTO system_states (system_name, team_id, state) VALUES($1, $2, $3) ON CONFLICT (system_name, team_id) DO UPDATE SET state = $3
+INSERT INTO system_states (system_name, team_id, state)
+VALUES($1, $2, $3)
+ON CONFLICT (system_name, team_id) DO
+    UPDATE SET state = $3
 `
 
 type SetTeamSystemStateParams struct {

--- a/sqlc/queries/api_keys.sql
+++ b/sqlc/queries/api_keys.sql
@@ -1,5 +1,7 @@
 -- name: CreateAPIKey :exec
-INSERT INTO api_keys (api_key, user_id) VALUES ($1, $2);
+INSERT INTO api_keys (api_key, user_id)
+VALUES ($1, $2);
 
--- name: RemoveApiKeysFromUser :exec
-DELETE FROM api_keys WHERE user_id = $1;
+-- name: RemoveApiKeysFromServiceAccount :exec
+DELETE FROM api_keys
+WHERE user_id = $1;

--- a/sqlc/queries/audit_logs.sql
+++ b/sqlc/queries/audit_logs.sql
@@ -1,6 +1,9 @@
 -- name: CreateAuditLog :exec
-INSERT INTO audit_logs (correlation_id, actor_email, system_name, target_user_email, target_team_slug, action, message)
+INSERT INTO audit_logs (correlation_id, actor, system_name, target_user, target_team_slug, action, message)
 VALUES ($1, $2, $3, $4, $5, $6, $7);
 
 -- name: GetAuditLogsForTeam :many
-SELECT * FROM audit_logs WHERE target_team_slug = $1 ORDER BY created_at DESC LIMIT 100;
+SELECT * FROM audit_logs
+WHERE target_team_slug = $1
+ORDER BY created_at DESC
+LIMIT 100;

--- a/sqlc/queries/reconcile_errors.sql
+++ b/sqlc/queries/reconcile_errors.sql
@@ -1,5 +1,6 @@
 -- name: ClearTeamReconcileErrorForSystem :exec
-DELETE FROM reconcile_errors WHERE team_id = $1 AND system_name = $2;
+DELETE FROM reconcile_errors
+WHERE team_id = $1 AND system_name = $2;
 
 -- name: SetTeamReconcileErrorForSystem :exec
 INSERT INTO reconcile_errors (correlation_id, team_id, system_name, error_message)
@@ -8,4 +9,6 @@ ON CONFLICT(team_id, system_name) DO
     UPDATE SET correlation_id = $1, created_at = NOW(), error_message = $4;
 
 -- name: GetTeamReconcileErrors :many
-SELECT * FROM reconcile_errors WHERE team_id = $1 ORDER BY created_at DESC;
+SELECT * FROM reconcile_errors
+WHERE team_id = $1
+ORDER BY created_at DESC;

--- a/sqlc/queries/roles.sql
+++ b/sqlc/queries/roles.sql
@@ -1,5 +1,32 @@
 -- name: GetRoleAuthorizations :many
-SELECT authz_name
-FROM role_authz
+SELECT authz_name FROM role_authz
 WHERE role_name = $1
 ORDER BY authz_name ASC;
+
+-- name: GetUserRoles :many
+SELECT * FROM user_roles
+WHERE user_id = $1;
+
+-- name: AssignGlobalRoleToUser :exec
+INSERT INTO user_roles (user_id, role_name)
+VALUES ($1, $2) ON CONFLICT DO NOTHING;
+
+-- name: RevokeGlobalRoleFromUser :exec
+DELETE FROM user_roles
+WHERE user_id = $1 AND role_name = $2;
+
+-- name: AssignTargetedRoleToUser :exec
+INSERT INTO user_roles (user_id, role_name, target_id)
+VALUES ($1, $2, $3) ON CONFLICT DO NOTHING;
+
+-- name: RevokeTargetedRoleFromUser :exec
+DELETE FROM user_roles
+WHERE user_id = $1 AND target_id = $2 AND role_name = $3;
+
+-- name: RemoveGlobalUserRole :exec
+DELETE FROM user_roles
+WHERE user_id = $1 AND target_id IS NULL AND role_name = $2;
+
+-- name: RemoveAllUserRoles :exec
+DELETE FROM user_roles
+WHERE user_id = $1;

--- a/sqlc/queries/system_states.sql
+++ b/sqlc/queries/system_states.sql
@@ -1,5 +1,9 @@
 -- name: GetTeamSystemState :one
-SELECT * FROM system_states WHERE system_name = $1 AND team_id = $2 LIMIT 1;
+SELECT * FROM system_states
+WHERE system_name = $1 AND team_id = $2;
 
 -- name: SetTeamSystemState :exec
-INSERT INTO system_states (system_name, team_id, state) VALUES($1, $2, $3) ON CONFLICT (system_name, team_id) DO UPDATE SET state = $3;
+INSERT INTO system_states (system_name, team_id, state)
+VALUES($1, $2, $3)
+ON CONFLICT (system_name, team_id) DO
+    UPDATE SET state = $3;

--- a/sqlc/queries/teams.sql
+++ b/sqlc/queries/teams.sql
@@ -1,28 +1,39 @@
 -- name: CreateTeam :one
-INSERT INTO teams (name, slug, purpose) VALUES ($1, $2, $3)
+INSERT INTO teams (name, slug, purpose)
+VALUES ($1, $2, $3)
 RETURNING *;
 
 -- name: GetTeams :many
-SELECT * FROM teams ORDER BY name ASC;
+SELECT * FROM teams
+ORDER BY name ASC;
 
 -- name: GetTeamByID :one
-SELECT * FROM teams WHERE id = $1 LIMIT 1;
+SELECT * FROM teams
+WHERE id = $1;
 
 -- name: GetTeamBySlug :one
-SELECT * FROM teams WHERE slug = $1 LIMIT 1;
+SELECT * FROM teams
+WHERE slug = $1;
 
 -- name: GetTeamMembers :many
 SELECT users.* FROM user_roles
 JOIN teams ON teams.id = user_roles.target_id
 JOIN users ON users.id = user_roles.user_id
-WHERE user_roles.target_id = sqlc.arg(team_id)::UUID
+WHERE user_roles.target_id = sqlc.arg(team_id)::UUID AND users.service_account = false
 ORDER BY users.name ASC;
 
 -- name: GetTeamMetadata :many
-SELECT * FROM team_metadata WHERE team_id = $1;
+SELECT * FROM team_metadata
+WHERE team_id = $1;
 
 -- name: SetTeamMetadata :exec
-INSERT INTO team_metadata (team_id, key, value) VALUES ($1, $2, $3) ON CONFLICT (team_id, key) DO UPDATE SET value = $3;
+INSERT INTO team_metadata (team_id, key, value)
+VALUES ($1, $2, $3)
+ON CONFLICT (team_id, key) DO
+    UPDATE SET value = $3;
 
 -- name: UpdateTeam :one
-UPDATE teams SET name = COALESCE(sqlc.narg(name), name), purpose = COALESCE(sqlc.arg(purpose), purpose) WHERE id = sqlc.arg(id) RETURNING *;
+UPDATE teams
+SET name = COALESCE(sqlc.narg(name), name), purpose = COALESCE(sqlc.arg(purpose), purpose)
+WHERE id = sqlc.arg(id)
+RETURNING *;

--- a/sqlc/schemas/0011_rename_audit_log_fields.down.sql
+++ b/sqlc/schemas/0011_rename_audit_log_fields.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE audit_logs RENAME actor TO actor_email;
+ALTER TABLE audit_logs RENAME target_user TO target_user_email;
+
+COMMIT;

--- a/sqlc/schemas/0011_rename_audit_log_fields.up.sql
+++ b/sqlc/schemas/0011_rename_audit_log_fields.up.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE audit_logs RENAME actor_email TO actor;
+ALTER TABLE audit_logs RENAME target_user_email TO target_user;
+
+COMMIT;

--- a/sqlc/schemas/0012_service_account_name_constraint.down.sql
+++ b/sqlc/schemas/0012_service_account_name_constraint.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE users DROP CONSTRAINT users_service_account_name_check;
+
+COMMIT;

--- a/sqlc/schemas/0012_service_account_name_constraint.up.sql
+++ b/sqlc/schemas/0012_service_account_name_constraint.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE users ADD CONSTRAINT users_service_account_name_check CHECK (name ~* '^[a-z][a-z0-9-]*[a-z0-9]$' OR service_account = false);
+
+COMMIT;

--- a/sqlc/schemas/0013_users_external_id.down.sql
+++ b/sqlc/schemas/0013_users_external_id.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE users DROP CONSTRAINT users_external_id_check;
+ALTER TABLE users DROP COLUMN external_id;
+
+COMMIT;

--- a/sqlc/schemas/0013_users_external_id.up.sql
+++ b/sqlc/schemas/0013_users_external_id.up.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+ALTER TABLE users ADD COLUMN external_id TEXT;
+UPDATE users SET external_id = email WHERE service_account = false;
+CREATE UNIQUE INDEX users_external_id_idx ON users (external_id);
+ALTER TABLE users ADD CONSTRAINT users_external_id_check CHECK (external_id IS NOT NULL OR service_account = true);
+
+COMMIT;


### PR DESCRIPTION
This commit will make a harder separation between regular users and service accounts. Service accounts can no longer be team members, and they will have separate types when exposed through the GraphQL API. A new union type has been created for the me query, since this now can return either a service account, or a user.

Also, the user sync now supports updating the email address of a user when the email address has been updated remotely. Fixes #40

An ADR has been written with regards to how users and service accounts are handled: ADR-002

Other minor fixes:

- vulncheck is now run together with staticcheck in the check target in the Makefile, which is executed in the Dockerfile when building.
- Actor email has been renamed to actor in different places throughout the code, since service accounts does not have email addresses. The actor value will now be either a users' email address, or a service accounts' name.
- The `UserTeam` type in the GraphQL API has been renamed to `TeamMembership`