### PR TITLE
Use slug as primary key for teams

### DIFF
--- a/cmd/console/main.go
+++ b/cmd/console/main.go
@@ -249,14 +249,14 @@ func reconcileTeams(ctx context.Context, database db.Database, reconcileInputs *
 				metrics.IncReconcilerCounter(name, metrics.ReconcilerStateFailed)
 				log.Error(err)
 				teamErrors++
-				err = database.SetReconcilerErrorForTeam(ctx, input.CorrelationID, input.Team.ID, name, err)
+				err = database.SetReconcilerErrorForTeam(ctx, input.CorrelationID, input.Team.Slug, name, err)
 				if err != nil {
 					log.Errorf("Unable to add reconcile error to the database: %s", err)
 				}
 				continue
 			}
 
-			err = database.ClearReconcilerErrorsForTeam(ctx, input.Team.ID, name)
+			err = database.ClearReconcilerErrorsForTeam(ctx, input.Team.Slug, name)
 			if err != nil {
 				log.Errorf("Unable to purge reconcile errors for reconciler %q and team %q: %s", name, input.Team.Slug, err)
 			}

--- a/cmd/legacy-migration/main.go
+++ b/cmd/legacy-migration/main.go
@@ -282,7 +282,7 @@ func run() error {
 				return err
 			}
 
-			_, err = dbtx.DisableTeam(ctx, team.ID)
+			_, err = dbtx.DisableTeam(ctx, team.Slug)
 			if err != nil {
 				return err
 			}

--- a/cmd/legacy-migration/main.go
+++ b/cmd/legacy-migration/main.go
@@ -175,7 +175,7 @@ func run() error {
 					return err
 				}
 
-				err = dbtx.SetTeamMetadata(ctx, team.ID, metadata)
+				err = dbtx.SetTeamMetadata(ctx, team.Slug, metadata)
 				if err != nil {
 					return err
 				}

--- a/cmd/legacy-migration/main.go
+++ b/cmd/legacy-migration/main.go
@@ -194,7 +194,7 @@ func run() error {
 			}
 
 			for _, user := range teamOwners {
-				err := dbtx.SetTeamMemberRole(ctx, user.ID, team.ID, sqlc.RoleNameTeamowner)
+				err := dbtx.SetTeamMemberRole(ctx, user.ID, team.Slug, sqlc.RoleNameTeamowner)
 				if err != nil {
 					return err
 				}
@@ -214,7 +214,7 @@ func run() error {
 			}
 
 			for _, user := range teamMembers {
-				err := dbtx.SetTeamMemberRole(ctx, user.ID, team.ID, sqlc.RoleNameTeammember)
+				err := dbtx.SetTeamMemberRole(ctx, user.ID, team.Slug, sqlc.RoleNameTeammember)
 				if err != nil {
 					return err
 				}

--- a/cmd/legacy-migration/main.go
+++ b/cmd/legacy-migration/main.go
@@ -233,14 +233,14 @@ func run() error {
 				}
 			}
 
-			err = dbtx.SetReconcilerStateForTeam(ctx, sqlc.ReconcilerNameAzureGroup, team.ID, reconcilers.AzureState{
+			err = dbtx.SetReconcilerStateForTeam(ctx, sqlc.ReconcilerNameAzureGroup, team.Slug, reconcilers.AzureState{
 				GroupID: &yamlteam.AzureGroupID,
 			})
 			if err != nil {
 				return err
 			}
 
-			err = dbtx.SetReconcilerStateForTeam(ctx, sqlc.ReconcilerNameGithubTeam, team.ID, reconcilers.GitHubState{
+			err = dbtx.SetReconcilerStateForTeam(ctx, sqlc.ReconcilerNameGithubTeam, team.Slug, reconcilers.GitHubState{
 				Slug: &team.Slug,
 			})
 			if err != nil {
@@ -248,7 +248,7 @@ func run() error {
 			}
 
 			googleWorkspaceGroupEmail := string(team.Slug) + "@" + cfg.TenantDomain
-			err = dbtx.SetReconcilerStateForTeam(ctx, sqlc.ReconcilerNameGoogleWorkspaceAdmin, team.ID, reconcilers.GoogleWorkspaceState{
+			err = dbtx.SetReconcilerStateForTeam(ctx, sqlc.ReconcilerNameGoogleWorkspaceAdmin, team.Slug, reconcilers.GoogleWorkspaceState{
 				GroupEmail: &googleWorkspaceGroupEmail,
 			})
 			if err != nil {
@@ -264,7 +264,7 @@ func run() error {
 			for env := range clusters {
 				projectMapping[env] = reconcilers.GoogleGcpEnvironmentProject{ProjectID: cachedMapping[env]}
 			}
-			err = dbtx.SetReconcilerStateForTeam(ctx, sqlc.ReconcilerNameGoogleGcpProject, team.ID, reconcilers.GoogleGcpProjectState{
+			err = dbtx.SetReconcilerStateForTeam(ctx, sqlc.ReconcilerNameGoogleGcpProject, team.Slug, reconcilers.GoogleGcpProjectState{
 				Projects: projectMapping,
 			})
 			if err != nil {
@@ -275,7 +275,7 @@ func run() error {
 			for env := range clusters {
 				naisNamespaces[env] = team.Slug
 			}
-			err = dbtx.SetReconcilerStateForTeam(ctx, sqlc.ReconcilerNameNaisNamespace, team.ID, reconcilers.GoogleGcpNaisNamespaceState{
+			err = dbtx.SetReconcilerStateForTeam(ctx, sqlc.ReconcilerNameNaisNamespace, team.Slug, reconcilers.GoogleGcpNaisNamespaceState{
 				Namespaces: naisNamespaces,
 			})
 			if err != nil {

--- a/graphql/roles.graphqls
+++ b/graphql/roles.graphqls
@@ -3,38 +3,6 @@ extend type Query {
     roles: [RoleName!]!
 }
 
-extend type Mutation {
-    """
-    Assign a global role to a user
-
-    Only users with the admin role are allowed to assign global roles.
-
-    The updated user is returned on success.
-    """
-    assignGlobalRoleToUser(
-        "The role to assign the user."
-        role: RoleName!
-
-        "The user that will be assiged the role."
-        userID: UUID!
-    ): User! @admin
-
-    """
-    Revoke a global role from a user
-
-    Only users with the admin role are allowed to revoke global roles.
-
-    The updated user is returned on success.
-    """
-    revokeGlobalRoleFromUser(
-        "The role to revoke from the user."
-        role: RoleName!
-
-        "The user to revoke the role from."
-        userID: UUID!
-    ): User! @admin
-}
-
 "Role binding type."
 type Role {
     "Name of the role."

--- a/graphql/roles.graphqls
+++ b/graphql/roles.graphqls
@@ -11,6 +11,9 @@ type Role {
     "Whether or not the role is global."
     isGlobal: Boolean!
 
-    "Optional target of the role binding."
-    targetId: UUID
+    "Optional service account ID if the role binding targets a service account."
+    targetServiceAccountID: UUID
+
+    "Optional team slug if the role binding targets a team."
+    targetTeamSlug: Slug
 }

--- a/graphql/teams.graphqls
+++ b/graphql/teams.graphqls
@@ -167,6 +167,9 @@ type Team {
 
     "Whether or not the team is enabled."
     enabled: Boolean!
+
+    "Timestamp of the last successful synchronization of the team."
+    lastSuccessfulSync: Time
 }
 
 "Team metadata type."

--- a/graphql/teams.graphqls
+++ b/graphql/teams.graphqls
@@ -4,8 +4,8 @@ extend type Query {
 
     "Get a specific team."
     team(
-        "ID of the team."
-        id: UUID!
+        "Slug of the team."
+        slug: Slug!
     ): Team! @auth
 }
 
@@ -30,8 +30,8 @@ extend type Mutation {
     The updated team will be returned on success.
     """
     updateTeam(
-        "ID of the team to update."
-        teamId: UUID!
+        "Slug of the team to update."
+        slug: Slug!
 
         "Input for updating the team."
         input: UpdateTeamInput!
@@ -56,8 +56,8 @@ extend type Mutation {
     The team will be returned.
     """
     synchronizeTeam(
-        "The ID of the team to synchronize."
-        teamId: UUID!
+        "The slug of the team to synchronize."
+        slug: Slug!
     ): TeamSync! @auth
 
     """
@@ -106,8 +106,8 @@ extend type Mutation {
     The team will be returned on success.
     """
     disableTeam(
-        "The ID of the team to disable."
-        teamId: UUID!
+        "The slug of the team to disable."
+        slug: Slug!
     ): Team! @auth
 
     """
@@ -116,8 +116,8 @@ extend type Mutation {
     The team will be returned on success.
     """
     enableTeam(
-        "The ID of the team to enable."
-        teamId: UUID!
+        "The slug of the team to enable."
+        slug: Slug!
     ): Team! @auth
 }
 
@@ -132,9 +132,6 @@ type TeamSync {
 
 "Team type."
 type Team {
-    "ID of the team."
-    id: UUID!
-
     "Unique slug of the team."
     slug: Slug!
 
@@ -213,8 +210,8 @@ input UpdateTeamInput {
 
 "Input for adding users to a team as members."
 input AddTeamMembersInput {
-    "ID of the team that should receive new members."
-    teamId: UUID!
+    "Slug of the team that should receive new members."
+    slug: Slug!
 
     "List of user IDs that should be added to the team as members."
     userIds: [UUID!]!
@@ -222,8 +219,8 @@ input AddTeamMembersInput {
 
 "Input for adding users to a team as owners."
 input AddTeamOwnersInput {
-    "ID of the team that should receive new owners."
-    teamId: UUID!
+    "Slug of the team that should receive new owners."
+    slug: Slug!
 
     "List of user IDs that should be added to the team as owners."
     userIds: [UUID!]!
@@ -231,17 +228,17 @@ input AddTeamOwnersInput {
 
 "Input for removing users from a team."
 input RemoveUsersFromTeamInput {
+    "Team slug that users should be removed from."
+    slug: Slug!
+
     "List of user IDs that should be removed from the team."
     userIds: [UUID!]!
-
-    "Team ID that users should be removed from."
-    teamId: UUID!
 }
 
 "Input for setting team member role."
 input SetTeamMemberRoleInput {
-    "The ID of the team."
-    teamId: UUID!
+    "The slug of the team."
+    slug: Slug!
 
     "The ID of the user."
     userId: UUID!

--- a/graphql/teams.graphqls
+++ b/graphql/teams.graphqls
@@ -43,8 +43,11 @@ extend type Mutation {
     The updated team will be returned on success.
     """
     removeUsersFromTeam(
-        "Input for removing users from a team."
-        input: RemoveUsersFromTeamInput!
+        "Team slug that users should be removed from."
+        slug: Slug!
+
+        "List of user IDs that should be removed from the team."
+        userIds: [UUID!]!
     ): Team! @auth
 
     """
@@ -69,8 +72,11 @@ extend type Mutation {
     The updated team will be returned on success.
     """
     addTeamMembers(
-        "Input for adding users to a team as members."
-        input: AddTeamMembersInput!
+        "Slug of the team that should receive new members."
+        slug: Slug!
+
+        "List of user IDs that should be added to the team as members."
+        userIds: [UUID!]!
     ): Team! @auth
 
     """
@@ -82,8 +88,11 @@ extend type Mutation {
     The updated team will be returned on success.
     """
     addTeamOwners(
-        "Input for adding users to a team as owners."
-        input: AddTeamOwnersInput!
+        "Slug of the team that should receive new owners."
+        slug: Slug!
+
+        "List of user IDs that should be added to the team as owners."
+        userIds: [UUID!]!
     ): Team! @auth
 
     """
@@ -94,8 +103,14 @@ extend type Mutation {
     The team will be returned on success.
     """
     setTeamMemberRole(
-        "Input for setting the team member role."
-        input: SetTeamMemberRoleInput!
+        "The slug of the team."
+        slug: Slug!
+
+        "The ID of the user."
+        userId: UUID!
+
+        "The team role to set."
+        role: TeamRole!
     ): Team! @auth
 
     """
@@ -206,45 +221,6 @@ input CreateTeamInput {
 input UpdateTeamInput {
     "Specify team purpose to update the existing value."
     purpose: String
-}
-
-"Input for adding users to a team as members."
-input AddTeamMembersInput {
-    "Slug of the team that should receive new members."
-    slug: Slug!
-
-    "List of user IDs that should be added to the team as members."
-    userIds: [UUID!]!
-}
-
-"Input for adding users to a team as owners."
-input AddTeamOwnersInput {
-    "Slug of the team that should receive new owners."
-    slug: Slug!
-
-    "List of user IDs that should be added to the team as owners."
-    userIds: [UUID!]!
-}
-
-"Input for removing users from a team."
-input RemoveUsersFromTeamInput {
-    "Team slug that users should be removed from."
-    slug: Slug!
-
-    "List of user IDs that should be removed from the team."
-    userIds: [UUID!]!
-}
-
-"Input for setting team member role."
-input SetTeamMemberRoleInput {
-    "The slug of the team."
-    slug: Slug!
-
-    "The ID of the user."
-    userId: UUID!
-
-    "The team role to set."
-    role: TeamRole!
 }
 
 "Available team roles."

--- a/pkg/db/database.go
+++ b/pkg/db/database.go
@@ -7,7 +7,6 @@ import (
 	"github.com/golang-migrate/migrate/v4"
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
 	"github.com/golang-migrate/migrate/v4/source/iofs"
-	"github.com/google/uuid"
 	"github.com/nais/console/sqlc/schemas"
 )
 
@@ -50,15 +49,5 @@ func nullString(s *string) sql.NullString {
 	return sql.NullString{
 		String: *s,
 		Valid:  true,
-	}
-}
-
-func nullUUID(ID *uuid.UUID) uuid.NullUUID {
-	if ID == nil {
-		return uuid.NullUUID{}
-	}
-	return uuid.NullUUID{
-		UUID:  *ID,
-		Valid: true,
 	}
 }

--- a/pkg/db/mock_database.go
+++ b/pkg/db/mock_database.go
@@ -60,13 +60,13 @@ func (_m *MockDatabase) AssignTargetedRoleToUser(ctx context.Context, userID uui
 	return r0
 }
 
-// ClearReconcilerErrorsForTeam provides a mock function with given fields: ctx, teamID, reconcilerName
-func (_m *MockDatabase) ClearReconcilerErrorsForTeam(ctx context.Context, teamID uuid.UUID, reconcilerName sqlc.ReconcilerName) error {
-	ret := _m.Called(ctx, teamID, reconcilerName)
+// ClearReconcilerErrorsForTeam provides a mock function with given fields: ctx, _a1, reconcilerName
+func (_m *MockDatabase) ClearReconcilerErrorsForTeam(ctx context.Context, _a1 slug.Slug, reconcilerName sqlc.ReconcilerName) error {
+	ret := _m.Called(ctx, _a1, reconcilerName)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID, sqlc.ReconcilerName) error); ok {
-		r0 = rf(ctx, teamID, reconcilerName)
+	if rf, ok := ret.Get(0).(func(context.Context, slug.Slug, sqlc.ReconcilerName) error); ok {
+		r0 = rf(ctx, _a1, reconcilerName)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -742,13 +742,13 @@ func (_m *MockDatabase) GetTeamMetadata(ctx context.Context, _a1 slug.Slug) ([]*
 	return r0, r1
 }
 
-// GetTeamReconcilerErrors provides a mock function with given fields: ctx, teamID
-func (_m *MockDatabase) GetTeamReconcilerErrors(ctx context.Context, teamID uuid.UUID) ([]*ReconcilerError, error) {
-	ret := _m.Called(ctx, teamID)
+// GetTeamReconcilerErrors provides a mock function with given fields: ctx, _a1
+func (_m *MockDatabase) GetTeamReconcilerErrors(ctx context.Context, _a1 slug.Slug) ([]*ReconcilerError, error) {
+	ret := _m.Called(ctx, _a1)
 
 	var r0 []*ReconcilerError
-	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID) []*ReconcilerError); ok {
-		r0 = rf(ctx, teamID)
+	if rf, ok := ret.Get(0).(func(context.Context, slug.Slug) []*ReconcilerError); ok {
+		r0 = rf(ctx, _a1)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*ReconcilerError)
@@ -756,8 +756,8 @@ func (_m *MockDatabase) GetTeamReconcilerErrors(ctx context.Context, teamID uuid
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, uuid.UUID) error); ok {
-		r1 = rf(ctx, teamID)
+	if rf, ok := ret.Get(1).(func(context.Context, slug.Slug) error); ok {
+		r1 = rf(ctx, _a1)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1033,13 +1033,13 @@ func (_m *MockDatabase) RevokeGlobalRoleFromUser(ctx context.Context, userID uui
 	return r0
 }
 
-// SetReconcilerErrorForTeam provides a mock function with given fields: ctx, correlationID, teamID, reconcilerName, err
-func (_m *MockDatabase) SetReconcilerErrorForTeam(ctx context.Context, correlationID uuid.UUID, teamID uuid.UUID, reconcilerName sqlc.ReconcilerName, err error) error {
-	ret := _m.Called(ctx, correlationID, teamID, reconcilerName, err)
+// SetReconcilerErrorForTeam provides a mock function with given fields: ctx, correlationID, _a2, reconcilerName, err
+func (_m *MockDatabase) SetReconcilerErrorForTeam(ctx context.Context, correlationID uuid.UUID, _a2 slug.Slug, reconcilerName sqlc.ReconcilerName, err error) error {
+	ret := _m.Called(ctx, correlationID, _a2, reconcilerName, err)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID, uuid.UUID, sqlc.ReconcilerName, error) error); ok {
-		r0 = rf(ctx, correlationID, teamID, reconcilerName, err)
+	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID, slug.Slug, sqlc.ReconcilerName, error) error); ok {
+		r0 = rf(ctx, correlationID, _a2, reconcilerName, err)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/pkg/db/mock_database.go
+++ b/pkg/db/mock_database.go
@@ -636,29 +636,6 @@ func (_m *MockDatabase) GetSessionByID(ctx context.Context, sessionID uuid.UUID)
 	return r0, r1
 }
 
-// GetTeamByID provides a mock function with given fields: ctx, ID
-func (_m *MockDatabase) GetTeamByID(ctx context.Context, ID uuid.UUID) (*Team, error) {
-	ret := _m.Called(ctx, ID)
-
-	var r0 *Team
-	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID) *Team); ok {
-		r0 = rf(ctx, ID)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*Team)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, uuid.UUID) error); ok {
-		r1 = rf(ctx, ID)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // GetTeamBySlug provides a mock function with given fields: ctx, _a1
 func (_m *MockDatabase) GetTeamBySlug(ctx context.Context, _a1 slug.Slug) (*Team, error) {
 	ret := _m.Called(ctx, _a1)

--- a/pkg/db/mock_database.go
+++ b/pkg/db/mock_database.go
@@ -926,13 +926,13 @@ func (_m *MockDatabase) GetUsers(ctx context.Context) ([]*User, error) {
 	return r0, r1
 }
 
-// LoadReconcilerStateForTeam provides a mock function with given fields: ctx, reconcilerName, teamID, state
-func (_m *MockDatabase) LoadReconcilerStateForTeam(ctx context.Context, reconcilerName sqlc.ReconcilerName, teamID uuid.UUID, state interface{}) error {
-	ret := _m.Called(ctx, reconcilerName, teamID, state)
+// LoadReconcilerStateForTeam provides a mock function with given fields: ctx, reconcilerName, _a2, state
+func (_m *MockDatabase) LoadReconcilerStateForTeam(ctx context.Context, reconcilerName sqlc.ReconcilerName, _a2 slug.Slug, state interface{}) error {
+	ret := _m.Called(ctx, reconcilerName, _a2, state)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, sqlc.ReconcilerName, uuid.UUID, interface{}) error); ok {
-		r0 = rf(ctx, reconcilerName, teamID, state)
+	if rf, ok := ret.Get(0).(func(context.Context, sqlc.ReconcilerName, slug.Slug, interface{}) error); ok {
+		r0 = rf(ctx, reconcilerName, _a2, state)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -1047,13 +1047,13 @@ func (_m *MockDatabase) SetReconcilerErrorForTeam(ctx context.Context, correlati
 	return r0
 }
 
-// SetReconcilerStateForTeam provides a mock function with given fields: ctx, reconcilerName, teamID, state
-func (_m *MockDatabase) SetReconcilerStateForTeam(ctx context.Context, reconcilerName sqlc.ReconcilerName, teamID uuid.UUID, state interface{}) error {
-	ret := _m.Called(ctx, reconcilerName, teamID, state)
+// SetReconcilerStateForTeam provides a mock function with given fields: ctx, reconcilerName, _a2, state
+func (_m *MockDatabase) SetReconcilerStateForTeam(ctx context.Context, reconcilerName sqlc.ReconcilerName, _a2 slug.Slug, state interface{}) error {
+	ret := _m.Called(ctx, reconcilerName, _a2, state)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, sqlc.ReconcilerName, uuid.UUID, interface{}) error); ok {
-		r0 = rf(ctx, reconcilerName, teamID, state)
+	if rf, ok := ret.Get(0).(func(context.Context, sqlc.ReconcilerName, slug.Slug, interface{}) error); ok {
+		r0 = rf(ctx, reconcilerName, _a2, state)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/pkg/db/mock_database.go
+++ b/pkg/db/mock_database.go
@@ -719,13 +719,13 @@ func (_m *MockDatabase) GetTeamMembers(ctx context.Context, teamID uuid.UUID) ([
 	return r0, r1
 }
 
-// GetTeamMetadata provides a mock function with given fields: ctx, teamID
-func (_m *MockDatabase) GetTeamMetadata(ctx context.Context, teamID uuid.UUID) ([]*TeamMetadata, error) {
-	ret := _m.Called(ctx, teamID)
+// GetTeamMetadata provides a mock function with given fields: ctx, _a1
+func (_m *MockDatabase) GetTeamMetadata(ctx context.Context, _a1 slug.Slug) ([]*TeamMetadata, error) {
+	ret := _m.Called(ctx, _a1)
 
 	var r0 []*TeamMetadata
-	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID) []*TeamMetadata); ok {
-		r0 = rf(ctx, teamID)
+	if rf, ok := ret.Get(0).(func(context.Context, slug.Slug) []*TeamMetadata); ok {
+		r0 = rf(ctx, _a1)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*TeamMetadata)
@@ -733,8 +733,8 @@ func (_m *MockDatabase) GetTeamMetadata(ctx context.Context, teamID uuid.UUID) (
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, uuid.UUID) error); ok {
-		r1 = rf(ctx, teamID)
+	if rf, ok := ret.Get(1).(func(context.Context, slug.Slug) error); ok {
+		r1 = rf(ctx, _a1)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1075,13 +1075,13 @@ func (_m *MockDatabase) SetTeamMemberRole(ctx context.Context, userID uuid.UUID,
 	return r0
 }
 
-// SetTeamMetadata provides a mock function with given fields: ctx, teamID, metadata
-func (_m *MockDatabase) SetTeamMetadata(ctx context.Context, teamID uuid.UUID, metadata []TeamMetadata) error {
-	ret := _m.Called(ctx, teamID, metadata)
+// SetTeamMetadata provides a mock function with given fields: ctx, _a1, metadata
+func (_m *MockDatabase) SetTeamMetadata(ctx context.Context, _a1 slug.Slug, metadata []TeamMetadata) error {
+	ret := _m.Called(ctx, _a1, metadata)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID, []TeamMetadata) error); ok {
-		r0 = rf(ctx, teamID, metadata)
+	if rf, ok := ret.Get(0).(func(context.Context, slug.Slug, []TeamMetadata) error); ok {
+		r0 = rf(ctx, _a1, metadata)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/pkg/db/mock_database.go
+++ b/pkg/db/mock_database.go
@@ -982,6 +982,20 @@ func (_m *MockDatabase) ResetReconcilerConfig(ctx context.Context, reconcilerNam
 	return r0, r1
 }
 
+// SetLastSuccessfulSyncForTeam provides a mock function with given fields: ctx, teamSlug
+func (_m *MockDatabase) SetLastSuccessfulSyncForTeam(ctx context.Context, teamSlug slug.Slug) error {
+	ret := _m.Called(ctx, teamSlug)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, slug.Slug) error); ok {
+		r0 = rf(ctx, teamSlug)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // SetReconcilerErrorForTeam provides a mock function with given fields: ctx, correlationID, _a2, reconcilerName, err
 func (_m *MockDatabase) SetReconcilerErrorForTeam(ctx context.Context, correlationID uuid.UUID, _a2 slug.Slug, reconcilerName sqlc.ReconcilerName, err error) error {
 	ret := _m.Called(ctx, correlationID, _a2, reconcilerName, err)

--- a/pkg/db/mock_database.go
+++ b/pkg/db/mock_database.go
@@ -291,13 +291,13 @@ func (_m *MockDatabase) DisableReconciler(ctx context.Context, reconcilerName sq
 	return r0, r1
 }
 
-// DisableTeam provides a mock function with given fields: ctx, teamID
-func (_m *MockDatabase) DisableTeam(ctx context.Context, teamID uuid.UUID) (*Team, error) {
-	ret := _m.Called(ctx, teamID)
+// DisableTeam provides a mock function with given fields: ctx, teamSlug
+func (_m *MockDatabase) DisableTeam(ctx context.Context, teamSlug slug.Slug) (*Team, error) {
+	ret := _m.Called(ctx, teamSlug)
 
 	var r0 *Team
-	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID) *Team); ok {
-		r0 = rf(ctx, teamID)
+	if rf, ok := ret.Get(0).(func(context.Context, slug.Slug) *Team); ok {
+		r0 = rf(ctx, teamSlug)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*Team)
@@ -305,8 +305,8 @@ func (_m *MockDatabase) DisableTeam(ctx context.Context, teamID uuid.UUID) (*Tea
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, uuid.UUID) error); ok {
-		r1 = rf(ctx, teamID)
+	if rf, ok := ret.Get(1).(func(context.Context, slug.Slug) error); ok {
+		r1 = rf(ctx, teamSlug)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -337,13 +337,13 @@ func (_m *MockDatabase) EnableReconciler(ctx context.Context, reconcilerName sql
 	return r0, r1
 }
 
-// EnableTeam provides a mock function with given fields: ctx, teamID
-func (_m *MockDatabase) EnableTeam(ctx context.Context, teamID uuid.UUID) (*Team, error) {
-	ret := _m.Called(ctx, teamID)
+// EnableTeam provides a mock function with given fields: ctx, teamSlug
+func (_m *MockDatabase) EnableTeam(ctx context.Context, teamSlug slug.Slug) (*Team, error) {
+	ret := _m.Called(ctx, teamSlug)
 
 	var r0 *Team
-	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID) *Team); ok {
-		r0 = rf(ctx, teamID)
+	if rf, ok := ret.Get(0).(func(context.Context, slug.Slug) *Team); ok {
+		r0 = rf(ctx, teamSlug)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*Team)
@@ -351,8 +351,8 @@ func (_m *MockDatabase) EnableTeam(ctx context.Context, teamID uuid.UUID) (*Team
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, uuid.UUID) error); ok {
-		r1 = rf(ctx, teamID)
+	if rf, ok := ret.Get(1).(func(context.Context, slug.Slug) error); ok {
+		r1 = rf(ctx, teamSlug)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1052,13 +1052,13 @@ func (_m *MockDatabase) Transaction(ctx context.Context, fn DatabaseTransactionF
 	return r0
 }
 
-// UpdateTeam provides a mock function with given fields: ctx, teamID, purpose
-func (_m *MockDatabase) UpdateTeam(ctx context.Context, teamID uuid.UUID, purpose *string) (*Team, error) {
-	ret := _m.Called(ctx, teamID, purpose)
+// UpdateTeam provides a mock function with given fields: ctx, teamSlug, purpose
+func (_m *MockDatabase) UpdateTeam(ctx context.Context, teamSlug slug.Slug, purpose *string) (*Team, error) {
+	ret := _m.Called(ctx, teamSlug, purpose)
 
 	var r0 *Team
-	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID, *string) *Team); ok {
-		r0 = rf(ctx, teamID, purpose)
+	if rf, ok := ret.Get(0).(func(context.Context, slug.Slug, *string) *Team); ok {
+		r0 = rf(ctx, teamSlug, purpose)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*Team)
@@ -1066,8 +1066,8 @@ func (_m *MockDatabase) UpdateTeam(ctx context.Context, teamID uuid.UUID, purpos
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, uuid.UUID, *string) error); ok {
-		r1 = rf(ctx, teamID, purpose)
+	if rf, ok := ret.Get(1).(func(context.Context, slug.Slug, *string) error); ok {
+		r1 = rf(ctx, teamSlug, purpose)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/db/mock_database.go
+++ b/pkg/db/mock_database.go
@@ -46,20 +46,6 @@ func (_m *MockDatabase) AssignGlobalRoleToUser(ctx context.Context, userID uuid.
 	return r0
 }
 
-// AssignTargetedRoleToUser provides a mock function with given fields: ctx, userID, roleName, targetID
-func (_m *MockDatabase) AssignTargetedRoleToUser(ctx context.Context, userID uuid.UUID, roleName sqlc.RoleName, targetID uuid.UUID) error {
-	ret := _m.Called(ctx, userID, roleName, targetID)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID, sqlc.RoleName, uuid.UUID) error); ok {
-		r0 = rf(ctx, userID, roleName, targetID)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // ClearReconcilerErrorsForTeam provides a mock function with given fields: ctx, _a1, reconcilerName
 func (_m *MockDatabase) ClearReconcilerErrorsForTeam(ctx context.Context, _a1 slug.Slug, reconcilerName sqlc.ReconcilerName) error {
 	ret := _m.Called(ctx, _a1, reconcilerName)
@@ -696,13 +682,13 @@ func (_m *MockDatabase) GetTeamBySlug(ctx context.Context, _a1 slug.Slug) (*Team
 	return r0, r1
 }
 
-// GetTeamMembers provides a mock function with given fields: ctx, teamID
-func (_m *MockDatabase) GetTeamMembers(ctx context.Context, teamID uuid.UUID) ([]*User, error) {
-	ret := _m.Called(ctx, teamID)
+// GetTeamMembers provides a mock function with given fields: ctx, teamSlug
+func (_m *MockDatabase) GetTeamMembers(ctx context.Context, teamSlug slug.Slug) ([]*User, error) {
+	ret := _m.Called(ctx, teamSlug)
 
 	var r0 []*User
-	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID) []*User); ok {
-		r0 = rf(ctx, teamID)
+	if rf, ok := ret.Get(0).(func(context.Context, slug.Slug) []*User); ok {
+		r0 = rf(ctx, teamSlug)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*User)
@@ -710,8 +696,8 @@ func (_m *MockDatabase) GetTeamMembers(ctx context.Context, teamID uuid.UUID) ([
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, uuid.UUID) error); ok {
-		r1 = rf(ctx, teamID)
+	if rf, ok := ret.Get(1).(func(context.Context, slug.Slug) error); ok {
+		r1 = rf(ctx, teamSlug)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -982,13 +968,13 @@ func (_m *MockDatabase) RemoveApiKeysFromServiceAccount(ctx context.Context, ser
 	return r0
 }
 
-// RemoveUserFromTeam provides a mock function with given fields: ctx, userID, teamID
-func (_m *MockDatabase) RemoveUserFromTeam(ctx context.Context, userID uuid.UUID, teamID uuid.UUID) error {
-	ret := _m.Called(ctx, userID, teamID)
+// RemoveUserFromTeam provides a mock function with given fields: ctx, userID, teamSlug
+func (_m *MockDatabase) RemoveUserFromTeam(ctx context.Context, userID uuid.UUID, teamSlug slug.Slug) error {
+	ret := _m.Called(ctx, userID, teamSlug)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID, uuid.UUID) error); ok {
-		r0 = rf(ctx, userID, teamID)
+	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID, slug.Slug) error); ok {
+		r0 = rf(ctx, userID, teamSlug)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -1019,20 +1005,6 @@ func (_m *MockDatabase) ResetReconcilerConfig(ctx context.Context, reconcilerNam
 	return r0, r1
 }
 
-// RevokeGlobalRoleFromUser provides a mock function with given fields: ctx, userID, roleName
-func (_m *MockDatabase) RevokeGlobalRoleFromUser(ctx context.Context, userID uuid.UUID, roleName sqlc.RoleName) error {
-	ret := _m.Called(ctx, userID, roleName)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID, sqlc.RoleName) error); ok {
-		r0 = rf(ctx, userID, roleName)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // SetReconcilerErrorForTeam provides a mock function with given fields: ctx, correlationID, _a2, reconcilerName, err
 func (_m *MockDatabase) SetReconcilerErrorForTeam(ctx context.Context, correlationID uuid.UUID, _a2 slug.Slug, reconcilerName sqlc.ReconcilerName, err error) error {
 	ret := _m.Called(ctx, correlationID, _a2, reconcilerName, err)
@@ -1061,13 +1033,13 @@ func (_m *MockDatabase) SetReconcilerStateForTeam(ctx context.Context, reconcile
 	return r0
 }
 
-// SetTeamMemberRole provides a mock function with given fields: ctx, userID, teamID, role
-func (_m *MockDatabase) SetTeamMemberRole(ctx context.Context, userID uuid.UUID, teamID uuid.UUID, role sqlc.RoleName) error {
-	ret := _m.Called(ctx, userID, teamID, role)
+// SetTeamMemberRole provides a mock function with given fields: ctx, userID, teamSlug, role
+func (_m *MockDatabase) SetTeamMemberRole(ctx context.Context, userID uuid.UUID, teamSlug slug.Slug, role sqlc.RoleName) error {
+	ret := _m.Called(ctx, userID, teamSlug, role)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID, uuid.UUID, sqlc.RoleName) error); ok {
-		r0 = rf(ctx, userID, teamID, role)
+	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID, slug.Slug, sqlc.RoleName) error); ok {
+		r0 = rf(ctx, userID, teamSlug, role)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -1149,20 +1121,20 @@ func (_m *MockDatabase) UpdateUser(ctx context.Context, userID uuid.UUID, name s
 	return r0, r1
 }
 
-// UserIsTeamOwner provides a mock function with given fields: ctx, userID, teamID
-func (_m *MockDatabase) UserIsTeamOwner(ctx context.Context, userID uuid.UUID, teamID uuid.UUID) (bool, error) {
-	ret := _m.Called(ctx, userID, teamID)
+// UserIsTeamOwner provides a mock function with given fields: ctx, userID, teamSlug
+func (_m *MockDatabase) UserIsTeamOwner(ctx context.Context, userID uuid.UUID, teamSlug slug.Slug) (bool, error) {
+	ret := _m.Called(ctx, userID, teamSlug)
 
 	var r0 bool
-	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID, uuid.UUID) bool); ok {
-		r0 = rf(ctx, userID, teamID)
+	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID, slug.Slug) bool); ok {
+		r0 = rf(ctx, userID, teamSlug)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, uuid.UUID, uuid.UUID) error); ok {
-		r1 = rf(ctx, userID, teamID)
+	if rf, ok := ret.Get(1).(func(context.Context, uuid.UUID, slug.Slug) error); ok {
+		r1 = rf(ctx, userID, teamSlug)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/db/reconciler_errors.go
+++ b/pkg/db/reconciler_errors.go
@@ -3,21 +3,23 @@ package db
 import (
 	"context"
 
+	"github.com/nais/console/pkg/slug"
+
 	"github.com/google/uuid"
 	"github.com/nais/console/pkg/sqlc"
 )
 
-func (d *database) SetReconcilerErrorForTeam(ctx context.Context, correlationID uuid.UUID, teamID uuid.UUID, reconcilerName sqlc.ReconcilerName, err error) error {
+func (d *database) SetReconcilerErrorForTeam(ctx context.Context, correlationID uuid.UUID, slug slug.Slug, reconcilerName sqlc.ReconcilerName, err error) error {
 	return d.querier.SetReconcilerErrorForTeam(ctx, sqlc.SetReconcilerErrorForTeamParams{
 		CorrelationID: correlationID,
-		TeamID:        teamID,
+		TeamSlug:      slug,
 		Reconciler:    reconcilerName,
 		ErrorMessage:  err.Error(),
 	})
 }
 
-func (d *database) GetTeamReconcilerErrors(ctx context.Context, teamID uuid.UUID) ([]*ReconcilerError, error) {
-	rows, err := d.querier.GetTeamReconcilerErrors(ctx, teamID)
+func (d *database) GetTeamReconcilerErrors(ctx context.Context, slug slug.Slug) ([]*ReconcilerError, error) {
+	rows, err := d.querier.GetTeamReconcilerErrors(ctx, slug)
 	if err != nil {
 		return nil, err
 	}
@@ -30,9 +32,9 @@ func (d *database) GetTeamReconcilerErrors(ctx context.Context, teamID uuid.UUID
 	return errors, nil
 }
 
-func (d *database) ClearReconcilerErrorsForTeam(ctx context.Context, teamID uuid.UUID, reconcilerName sqlc.ReconcilerName) error {
+func (d *database) ClearReconcilerErrorsForTeam(ctx context.Context, slug slug.Slug, reconcilerName sqlc.ReconcilerName) error {
 	return d.querier.ClearReconcilerErrorsForTeam(ctx, sqlc.ClearReconcilerErrorsForTeamParams{
-		TeamID:     teamID,
+		TeamSlug:   slug,
 		Reconciler: reconcilerName,
 	})
 }

--- a/pkg/db/reconciler_state.go
+++ b/pkg/db/reconciler_state.go
@@ -4,16 +4,17 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/uuid"
+	"github.com/nais/console/pkg/slug"
+
 	"github.com/jackc/pgtype"
 	"github.com/nais/console/pkg/sqlc"
 )
 
 // LoadReconcilerStateForTeam Load the team state for a given reconciler into the state parameter
-func (d *database) LoadReconcilerStateForTeam(ctx context.Context, reconcilerName sqlc.ReconcilerName, teamID uuid.UUID, state interface{}) error {
+func (d *database) LoadReconcilerStateForTeam(ctx context.Context, reconcilerName sqlc.ReconcilerName, slug slug.Slug, state interface{}) error {
 	systemState, err := d.querier.GetReconcilerStateForTeam(ctx, sqlc.GetReconcilerStateForTeamParams{
 		Reconciler: reconcilerName,
-		TeamID:     teamID,
+		TeamSlug:   slug,
 	})
 	if err != nil {
 		// assume empty state
@@ -29,7 +30,7 @@ func (d *database) LoadReconcilerStateForTeam(ctx context.Context, reconcilerNam
 }
 
 // SetReconcilerStateForTeam Update the team state for a given reconciler
-func (d *database) SetReconcilerStateForTeam(ctx context.Context, reconcilerName sqlc.ReconcilerName, teamID uuid.UUID, state interface{}) error {
+func (d *database) SetReconcilerStateForTeam(ctx context.Context, reconcilerName sqlc.ReconcilerName, slug slug.Slug, state interface{}) error {
 	newState := pgtype.JSONB{}
 	err := newState.Set(state)
 	if err != nil {
@@ -38,7 +39,7 @@ func (d *database) SetReconcilerStateForTeam(ctx context.Context, reconcilerName
 
 	return d.querier.SetReconcilerStateForTeam(ctx, sqlc.SetReconcilerStateForTeamParams{
 		Reconciler: reconcilerName,
-		TeamID:     teamID,
+		TeamSlug:   slug,
 		State:      newState,
 	})
 }

--- a/pkg/db/role.go
+++ b/pkg/db/role.go
@@ -3,6 +3,8 @@ package db
 import (
 	"context"
 
+	"github.com/nais/console/pkg/slug"
+
 	"github.com/google/uuid"
 	"github.com/nais/console/pkg/sqlc"
 )
@@ -21,39 +23,29 @@ func (d *database) AssignGlobalRoleToServiceAccount(ctx context.Context, service
 	})
 }
 
-func (d *database) RevokeGlobalRoleFromUser(ctx context.Context, userID uuid.UUID, roleName sqlc.RoleName) error {
-	return d.querier.RevokeGlobalRoleFromUser(ctx, sqlc.RevokeGlobalRoleFromUserParams{
-		UserID:   userID,
-		RoleName: roleName,
-	})
-}
-
-func (d *database) AssignTargetedRoleToUser(ctx context.Context, userID uuid.UUID, roleName sqlc.RoleName, targetID uuid.UUID) error {
-	return d.querier.AssignTargetedRoleToUser(ctx, sqlc.AssignTargetedRoleToUserParams{
-		UserID:   userID,
-		RoleName: roleName,
-		TargetID: nullUUID(&targetID),
-	})
-}
-
 // IsGlobal Check if the role is globally assigned or not
 func (r Role) IsGlobal() bool {
-	return r.TargetID == nil
+	return r.TargetServiceAccountID == nil && r.TargetTeamSlug == nil
 }
 
-// Targets Check if the role targets a specific ID
-func (r Role) Targets(targetID uuid.UUID) bool {
-	return r.TargetID != nil && *r.TargetID == targetID
+// TargetsTeam Check if the role targets a specific team
+func (r Role) TargetsTeam(targetsTeamSlug slug.Slug) bool {
+	return r.TargetTeamSlug != nil && *r.TargetTeamSlug == targetsTeamSlug
 }
 
-func (d *database) UserIsTeamOwner(ctx context.Context, userID, teamID uuid.UUID) (bool, error) {
+// TargetsServiceAccount Check if the role targets a specific service account
+func (r Role) TargetsServiceAccount(targetServiceAccountID uuid.UUID) bool {
+	return r.TargetServiceAccountID != nil && *r.TargetServiceAccountID == targetServiceAccountID
+}
+
+func (d *database) UserIsTeamOwner(ctx context.Context, userID uuid.UUID, teamSlug slug.Slug) (bool, error) {
 	roles, err := d.querier.GetUserRoles(ctx, userID)
 	if err != nil {
 		return false, err
 	}
 
 	for _, role := range roles {
-		if role.RoleName == sqlc.RoleNameTeamowner && role.TargetID.UUID == teamID {
+		if role.RoleName == sqlc.RoleNameTeamowner && role.TargetTeamSlug != nil && *role.TargetTeamSlug == teamSlug {
 			return true, nil
 		}
 	}
@@ -61,30 +53,20 @@ func (d *database) UserIsTeamOwner(ctx context.Context, userID, teamID uuid.UUID
 	return false, nil
 }
 
-func (d *database) SetTeamMemberRole(ctx context.Context, userID uuid.UUID, teamID uuid.UUID, role sqlc.RoleName) error {
+func (d *database) SetTeamMemberRole(ctx context.Context, userID uuid.UUID, teamSlug slug.Slug, role sqlc.RoleName) error {
 	return d.querier.Transaction(ctx, func(ctx context.Context, querier Querier) error {
-		err := querier.RevokeTargetedRoleFromUser(ctx, sqlc.RevokeTargetedRoleFromUserParams{
-			UserID:   userID,
-			TargetID: nullUUID(&teamID),
-			RoleName: sqlc.RoleNameTeamowner,
+		err := querier.RemoveUserFromTeam(ctx, sqlc.RemoveUserFromTeamParams{
+			UserID:         userID,
+			TargetTeamSlug: &teamSlug,
 		})
 		if err != nil {
 			return err
 		}
 
-		err = querier.RevokeTargetedRoleFromUser(ctx, sqlc.RevokeTargetedRoleFromUserParams{
-			UserID:   userID,
-			TargetID: nullUUID(&teamID),
-			RoleName: sqlc.RoleNameTeammember,
-		})
-		if err != nil {
-			return err
-		}
-
-		err = querier.AssignTargetedRoleToUser(ctx, sqlc.AssignTargetedRoleToUserParams{
-			UserID:   userID,
-			TargetID: nullUUID(&teamID),
-			RoleName: role,
+		err = querier.AssignTeamRoleToUser(ctx, sqlc.AssignTeamRoleToUserParams{
+			UserID:         userID,
+			TargetTeamSlug: &teamSlug,
+			RoleName:       role,
 		})
 		if err != nil {
 			return err
@@ -94,20 +76,21 @@ func (d *database) SetTeamMemberRole(ctx context.Context, userID uuid.UUID, team
 	})
 }
 
-func (d *database) roleFromRoleBinding(ctx context.Context, roleName sqlc.RoleName, targetID uuid.NullUUID) (*Role, error) {
+func (d *database) roleFromRoleBinding(ctx context.Context, roleName sqlc.RoleName, targetServiceAccountID uuid.NullUUID, targetTeamSlug *slug.Slug) (*Role, error) {
 	authorizations, err := d.querier.GetRoleAuthorizations(ctx, roleName)
 	if err != nil {
 		return nil, err
 	}
 
-	var id *uuid.UUID
-	if targetID.Valid {
-		id = &targetID.UUID
+	var saID *uuid.UUID
+	if targetServiceAccountID.Valid {
+		saID = &targetServiceAccountID.UUID
 	}
 
 	return &Role{
-		Authorizations: authorizations,
-		RoleName:       roleName,
-		TargetID:       id,
+		Authorizations:         authorizations,
+		RoleName:               roleName,
+		TargetServiceAccountID: saID,
+		TargetTeamSlug:         targetTeamSlug,
 	}, nil
 }

--- a/pkg/db/role_test.go
+++ b/pkg/db/role_test.go
@@ -3,31 +3,32 @@ package db_test
 import (
 	"testing"
 
-	"github.com/google/uuid"
+	"github.com/nais/console/pkg/slug"
+
 	"github.com/nais/console/pkg/db"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestRole_IsGlobal(t *testing.T) {
-	targetID := uuid.New()
-	r1 := db.Role{TargetID: &targetID}
+	targetTeamSlug := slug.Slug("slug")
+	r1 := db.Role{TargetTeamSlug: &targetTeamSlug}
 	r2 := db.Role{}
 	assert.False(t, r1.IsGlobal())
 	assert.True(t, r2.IsGlobal())
 }
 
 func TestRole_Targets(t *testing.T) {
-	id1 := uuid.New()
-	id2 := uuid.New()
-	r1 := db.Role{TargetID: &id1}
-	r2 := db.Role{TargetID: &id2}
+	slug1 := slug.Slug("slug1")
+	slug2 := slug.Slug("slug2")
+	r1 := db.Role{TargetTeamSlug: &slug1}
+	r2 := db.Role{TargetTeamSlug: &slug2}
 	r3 := db.Role{}
 
-	assert.True(t, r1.Targets(id1))
-	assert.False(t, r2.Targets(id1))
-	assert.False(t, r3.Targets(id1))
+	assert.True(t, r1.TargetsTeam(slug1))
+	assert.False(t, r2.TargetsTeam(slug1))
+	assert.False(t, r3.TargetsTeam(slug1))
 
-	assert.False(t, r1.Targets(id2))
-	assert.True(t, r2.Targets(id2))
-	assert.False(t, r3.Targets(id2))
+	assert.False(t, r1.TargetsTeam(slug2))
+	assert.True(t, r2.TargetsTeam(slug2))
+	assert.False(t, r3.TargetsTeam(slug2))
 }

--- a/pkg/db/service_accounts.go
+++ b/pkg/db/service_accounts.go
@@ -65,7 +65,7 @@ func (d *database) GetServiceAccountRoles(ctx context.Context, serviceAccountID 
 
 	roles := make([]*Role, 0, len(serviceAccountRoles))
 	for _, serviceAccountRole := range serviceAccountRoles {
-		role, err := d.roleFromRoleBinding(ctx, serviceAccountRole.RoleName, serviceAccountRole.TargetID)
+		role, err := d.roleFromRoleBinding(ctx, serviceAccountRole.RoleName, serviceAccountRole.TargetServiceAccountID, serviceAccountRole.TargetTeamSlug)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/db/team.go
+++ b/pkg/db/team.go
@@ -86,15 +86,6 @@ func (d *database) GetTeamBySlug(ctx context.Context, slug slug.Slug) (*Team, er
 	return &Team{Team: team}, nil
 }
 
-func (d *database) GetTeamByID(ctx context.Context, id uuid.UUID) (*Team, error) {
-	team, err := d.querier.GetTeamByID(ctx, id)
-	if err != nil {
-		return nil, err
-	}
-
-	return &Team{Team: team}, nil
-}
-
 func (d *database) GetTeams(ctx context.Context) ([]*Team, error) {
 	teams, err := d.querier.GetTeams(ctx)
 	if err != nil {

--- a/pkg/db/team.go
+++ b/pkg/db/team.go
@@ -145,3 +145,7 @@ func (d *database) EnableTeam(ctx context.Context, teamSlug slug.Slug) (*Team, e
 
 	return &Team{Team: team}, nil
 }
+
+func (d *database) SetLastSuccessfulSyncForTeam(ctx context.Context, teamSlug slug.Slug) error {
+	return d.querier.SetLastSuccessfulSyncForTeam(ctx, teamSlug)
+}

--- a/pkg/db/team.go
+++ b/pkg/db/team.go
@@ -46,20 +46,10 @@ func (d *database) SetTeamMetadata(ctx context.Context, slug slug.Slug, metadata
 	})
 }
 
-func (d *database) RemoveUserFromTeam(ctx context.Context, userID uuid.UUID, teamID uuid.UUID) error {
-	err := d.querier.RevokeTargetedRoleFromUser(ctx, sqlc.RevokeTargetedRoleFromUserParams{
-		UserID:   userID,
-		TargetID: nullUUID(&teamID),
-		RoleName: sqlc.RoleNameTeammember,
-	})
-	if err != nil {
-		return err
-	}
-
-	return d.querier.RevokeTargetedRoleFromUser(ctx, sqlc.RevokeTargetedRoleFromUserParams{
-		UserID:   userID,
-		TargetID: nullUUID(&teamID),
-		RoleName: sqlc.RoleNameTeamowner,
+func (d *database) RemoveUserFromTeam(ctx context.Context, userID uuid.UUID, teamSlug slug.Slug) error {
+	return d.querier.RemoveUserFromTeam(ctx, sqlc.RemoveUserFromTeamParams{
+		UserID:         userID,
+		TargetTeamSlug: &teamSlug,
 	})
 }
 
@@ -133,8 +123,8 @@ func (d *database) GetUserTeams(ctx context.Context, userID uuid.UUID) ([]*Team,
 	return teams, nil
 }
 
-func (d *database) GetTeamMembers(ctx context.Context, teamID uuid.UUID) ([]*User, error) {
-	rows, err := d.querier.GetTeamMembers(ctx, teamID)
+func (d *database) GetTeamMembers(ctx context.Context, teamSlug slug.Slug) ([]*User, error) {
+	rows, err := d.querier.GetTeamMembers(ctx, &teamSlug)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/db/team.go
+++ b/pkg/db/team.go
@@ -53,9 +53,9 @@ func (d *database) RemoveUserFromTeam(ctx context.Context, userID uuid.UUID, tea
 	})
 }
 
-func (d *database) UpdateTeam(ctx context.Context, teamID uuid.UUID, purpose *string) (*Team, error) {
+func (d *database) UpdateTeam(ctx context.Context, teamSlug slug.Slug, purpose *string) (*Team, error) {
 	team, err := d.querier.UpdateTeam(ctx, sqlc.UpdateTeamParams{
-		ID:      teamID,
+		Slug:    teamSlug,
 		Purpose: nullString(purpose),
 	})
 	if err != nil {
@@ -128,8 +128,8 @@ func (d *database) GetTeamMembers(ctx context.Context, teamSlug slug.Slug) ([]*U
 	return members, nil
 }
 
-func (d *database) DisableTeam(ctx context.Context, teamID uuid.UUID) (*Team, error) {
-	team, err := d.querier.DisableTeam(ctx, teamID)
+func (d *database) DisableTeam(ctx context.Context, teamSlug slug.Slug) (*Team, error) {
+	team, err := d.querier.DisableTeam(ctx, teamSlug)
 	if err != nil {
 		return nil, err
 	}
@@ -137,8 +137,8 @@ func (d *database) DisableTeam(ctx context.Context, teamID uuid.UUID) (*Team, er
 	return &Team{Team: team}, nil
 }
 
-func (d *database) EnableTeam(ctx context.Context, teamID uuid.UUID) (*Team, error) {
-	team, err := d.querier.EnableTeam(ctx, teamID)
+func (d *database) EnableTeam(ctx context.Context, teamSlug slug.Slug) (*Team, error) {
+	team, err := d.querier.EnableTeam(ctx, teamSlug)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/db/team.go
+++ b/pkg/db/team.go
@@ -8,8 +8,8 @@ import (
 	"github.com/nais/console/pkg/sqlc"
 )
 
-func (d *database) GetTeamMetadata(ctx context.Context, teamID uuid.UUID) ([]*TeamMetadata, error) {
-	rows, err := d.querier.GetTeamMetadata(ctx, teamID)
+func (d *database) GetTeamMetadata(ctx context.Context, slug slug.Slug) ([]*TeamMetadata, error) {
+	rows, err := d.querier.GetTeamMetadata(ctx, slug)
 	if err != nil {
 		return nil, err
 	}
@@ -29,13 +29,13 @@ func (d *database) GetTeamMetadata(ctx context.Context, teamID uuid.UUID) ([]*Te
 	return metadata, nil
 }
 
-func (d *database) SetTeamMetadata(ctx context.Context, teamID uuid.UUID, metadata []TeamMetadata) error {
+func (d *database) SetTeamMetadata(ctx context.Context, slug slug.Slug, metadata []TeamMetadata) error {
 	return d.querier.Transaction(ctx, func(ctx context.Context, querier Querier) error {
 		for _, entry := range metadata {
 			err := querier.SetTeamMetadata(ctx, sqlc.SetTeamMetadataParams{
-				TeamID: teamID,
-				Key:    entry.Key,
-				Value:  nullString(entry.Value),
+				TeamSlug: slug,
+				Key:      entry.Key,
+				Value:    nullString(entry.Value),
 			})
 			if err != nil {
 				return err

--- a/pkg/db/types.go
+++ b/pkg/db/types.go
@@ -102,8 +102,8 @@ type Database interface {
 	GetUsers(ctx context.Context) ([]*User, error)
 	GetUserTeams(ctx context.Context, userID uuid.UUID) ([]*Team, error)
 	CreateTeam(ctx context.Context, slug slug.Slug, purpose string) (*Team, error)
-	SetTeamMetadata(ctx context.Context, teamID uuid.UUID, metadata []TeamMetadata) error
-	GetTeamMetadata(ctx context.Context, teamID uuid.UUID) ([]*TeamMetadata, error)
+	SetTeamMetadata(ctx context.Context, slug slug.Slug, metadata []TeamMetadata) error
+	GetTeamMetadata(ctx context.Context, slug slug.Slug) ([]*TeamMetadata, error)
 	UpdateTeam(ctx context.Context, teamID uuid.UUID, purpose *string) (*Team, error)
 	GetTeamByID(ctx context.Context, ID uuid.UUID) (*Team, error)
 	GetTeamBySlug(ctx context.Context, slug slug.Slug) (*Team, error)

--- a/pkg/db/types.go
+++ b/pkg/db/types.go
@@ -105,7 +105,7 @@ type Database interface {
 	CreateTeam(ctx context.Context, slug slug.Slug, purpose string) (*Team, error)
 	SetTeamMetadata(ctx context.Context, slug slug.Slug, metadata []TeamMetadata) error
 	GetTeamMetadata(ctx context.Context, slug slug.Slug) ([]*TeamMetadata, error)
-	UpdateTeam(ctx context.Context, teamID uuid.UUID, purpose *string) (*Team, error)
+	UpdateTeam(ctx context.Context, teamSlug slug.Slug, purpose *string) (*Team, error)
 	GetTeamBySlug(ctx context.Context, slug slug.Slug) (*Team, error)
 	GetTeams(ctx context.Context) ([]*Team, error)
 	GetTeamMembers(ctx context.Context, teamSlug slug.Slug) ([]*User, error)
@@ -145,8 +145,8 @@ type Database interface {
 	DisableReconciler(ctx context.Context, reconcilerName sqlc.ReconcilerName) (*Reconciler, error)
 	DangerousGetReconcilerConfigValues(ctx context.Context, reconcilerName sqlc.ReconcilerName) (*ReconcilerConfigValues, error)
 	GetAuditLogsForReconciler(ctx context.Context, reconcilerName sqlc.ReconcilerName) ([]*AuditLog, error)
-	DisableTeam(ctx context.Context, teamID uuid.UUID) (*Team, error)
-	EnableTeam(ctx context.Context, teamID uuid.UUID) (*Team, error)
+	DisableTeam(ctx context.Context, teamSlug slug.Slug) (*Team, error)
+	EnableTeam(ctx context.Context, teamSlug slug.Slug) (*Team, error)
 }
 
 func (u User) GetID() uuid.UUID {

--- a/pkg/db/types.go
+++ b/pkg/db/types.go
@@ -106,7 +106,6 @@ type Database interface {
 	SetTeamMetadata(ctx context.Context, slug slug.Slug, metadata []TeamMetadata) error
 	GetTeamMetadata(ctx context.Context, slug slug.Slug) ([]*TeamMetadata, error)
 	UpdateTeam(ctx context.Context, teamID uuid.UUID, purpose *string) (*Team, error)
-	GetTeamByID(ctx context.Context, ID uuid.UUID) (*Team, error)
 	GetTeamBySlug(ctx context.Context, slug slug.Slug) (*Team, error)
 	GetTeams(ctx context.Context) ([]*Team, error)
 	GetTeamMembers(ctx context.Context, teamSlug slug.Slug) ([]*User, error)

--- a/pkg/db/types.go
+++ b/pkg/db/types.go
@@ -49,9 +49,10 @@ type ReconcilerError struct {
 }
 
 type Role struct {
-	Authorizations []sqlc.AuthzName
-	RoleName       sqlc.RoleName
-	TargetID       *uuid.UUID
+	Authorizations         []sqlc.AuthzName
+	RoleName               sqlc.RoleName
+	TargetServiceAccountID *uuid.UUID
+	TargetTeamSlug         *slug.Slug
 }
 
 type ServiceAccount struct {
@@ -108,15 +109,13 @@ type Database interface {
 	GetTeamByID(ctx context.Context, ID uuid.UUID) (*Team, error)
 	GetTeamBySlug(ctx context.Context, slug slug.Slug) (*Team, error)
 	GetTeams(ctx context.Context) ([]*Team, error)
-	GetTeamMembers(ctx context.Context, teamID uuid.UUID) ([]*User, error)
-	UserIsTeamOwner(ctx context.Context, userID, teamID uuid.UUID) (bool, error)
-	SetTeamMemberRole(ctx context.Context, userID uuid.UUID, teamID uuid.UUID, role sqlc.RoleName) error
+	GetTeamMembers(ctx context.Context, teamSlug slug.Slug) ([]*User, error)
+	UserIsTeamOwner(ctx context.Context, userID uuid.UUID, teamSlug slug.Slug) (bool, error)
+	SetTeamMemberRole(ctx context.Context, userID uuid.UUID, teamSlug slug.Slug, role sqlc.RoleName) error
 	GetAuditLogsForTeam(ctx context.Context, slug slug.Slug) ([]*AuditLog, error)
 	AssignGlobalRoleToUser(ctx context.Context, userID uuid.UUID, roleName sqlc.RoleName) error
 	AssignGlobalRoleToServiceAccount(ctx context.Context, serviceAccountID uuid.UUID, roleName sqlc.RoleName) error
-	RevokeGlobalRoleFromUser(ctx context.Context, userID uuid.UUID, roleName sqlc.RoleName) error
-	AssignTargetedRoleToUser(ctx context.Context, userID uuid.UUID, roleName sqlc.RoleName, targetID uuid.UUID) error
-	RemoveUserFromTeam(ctx context.Context, userID uuid.UUID, teamID uuid.UUID) error
+	RemoveUserFromTeam(ctx context.Context, userID uuid.UUID, teamSlug slug.Slug) error
 	CreateAPIKey(ctx context.Context, apiKey string, serviceAccountID uuid.UUID) error
 	RemoveAllUserRoles(ctx context.Context, userID uuid.UUID) error
 	RemoveAllServiceAccountRoles(ctx context.Context, serviceAccountID uuid.UUID) error

--- a/pkg/db/types.go
+++ b/pkg/db/types.go
@@ -124,8 +124,8 @@ type Database interface {
 	GetUserRoles(ctx context.Context, userID uuid.UUID) ([]*Role, error)
 	GetServiceAccountRoles(ctx context.Context, serviceAccountID uuid.UUID) ([]*Role, error)
 	Transaction(ctx context.Context, fn DatabaseTransactionFunc) error
-	LoadReconcilerStateForTeam(ctx context.Context, reconcilerName sqlc.ReconcilerName, teamID uuid.UUID, state interface{}) error
-	SetReconcilerStateForTeam(ctx context.Context, reconcilerName sqlc.ReconcilerName, teamID uuid.UUID, state interface{}) error
+	LoadReconcilerStateForTeam(ctx context.Context, reconcilerName sqlc.ReconcilerName, slug slug.Slug, state interface{}) error
+	SetReconcilerStateForTeam(ctx context.Context, reconcilerName sqlc.ReconcilerName, slug slug.Slug, state interface{}) error
 	UpdateUser(ctx context.Context, userID uuid.UUID, name, email, externalID string) (*User, error)
 	SetReconcilerErrorForTeam(ctx context.Context, correlationID uuid.UUID, teamID uuid.UUID, reconcilerName sqlc.ReconcilerName, err error) error
 	GetTeamReconcilerErrors(ctx context.Context, teamID uuid.UUID) ([]*ReconcilerError, error)

--- a/pkg/db/types.go
+++ b/pkg/db/types.go
@@ -127,9 +127,9 @@ type Database interface {
 	LoadReconcilerStateForTeam(ctx context.Context, reconcilerName sqlc.ReconcilerName, slug slug.Slug, state interface{}) error
 	SetReconcilerStateForTeam(ctx context.Context, reconcilerName sqlc.ReconcilerName, slug slug.Slug, state interface{}) error
 	UpdateUser(ctx context.Context, userID uuid.UUID, name, email, externalID string) (*User, error)
-	SetReconcilerErrorForTeam(ctx context.Context, correlationID uuid.UUID, teamID uuid.UUID, reconcilerName sqlc.ReconcilerName, err error) error
-	GetTeamReconcilerErrors(ctx context.Context, teamID uuid.UUID) ([]*ReconcilerError, error)
-	ClearReconcilerErrorsForTeam(ctx context.Context, teamID uuid.UUID, reconcilerName sqlc.ReconcilerName) error
+	SetReconcilerErrorForTeam(ctx context.Context, correlationID uuid.UUID, slug slug.Slug, reconcilerName sqlc.ReconcilerName, err error) error
+	GetTeamReconcilerErrors(ctx context.Context, slug slug.Slug) ([]*ReconcilerError, error)
+	ClearReconcilerErrorsForTeam(ctx context.Context, slug slug.Slug, reconcilerName sqlc.ReconcilerName) error
 	GetServiceAccounts(ctx context.Context) ([]*ServiceAccount, error)
 	DeleteServiceAccount(ctx context.Context, serviceAccountID uuid.UUID) error
 	GetUserByExternalID(ctx context.Context, externalID string) (*User, error)

--- a/pkg/db/types.go
+++ b/pkg/db/types.go
@@ -147,6 +147,7 @@ type Database interface {
 	GetAuditLogsForReconciler(ctx context.Context, reconcilerName sqlc.ReconcilerName) ([]*AuditLog, error)
 	DisableTeam(ctx context.Context, teamSlug slug.Slug) (*Team, error)
 	EnableTeam(ctx context.Context, teamSlug slug.Slug) (*Team, error)
+	SetLastSuccessfulSyncForTeam(ctx context.Context, teamSlug slug.Slug) error
 }
 
 func (u User) GetID() uuid.UUID {

--- a/pkg/db/user.go
+++ b/pkg/db/user.go
@@ -95,7 +95,7 @@ func (d *database) GetUserRoles(ctx context.Context, userID uuid.UUID) ([]*Role,
 
 	roles := make([]*Role, 0, len(userRoles))
 	for _, userRole := range userRoles {
-		role, err := d.roleFromRoleBinding(ctx, userRole.RoleName, userRole.TargetID)
+		role, err := d.roleFromRoleBinding(ctx, userRole.RoleName, userRole.TargetServiceAccountID, userRole.TargetTeamSlug)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/fixtures/naisteam.go
+++ b/pkg/fixtures/naisteam.go
@@ -2,6 +2,7 @@ package fixtures
 
 import (
 	"context"
+
 	"github.com/jackc/pgx/v4"
 	"github.com/nais/console/pkg/db"
 )

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -118,9 +118,10 @@ type ComplexityRoot struct {
 	}
 
 	Role struct {
-		IsGlobal func(childComplexity int) int
-		Name     func(childComplexity int) int
-		TargetID func(childComplexity int) int
+		IsGlobal               func(childComplexity int) int
+		Name                   func(childComplexity int) int
+		TargetServiceAccountID func(childComplexity int) int
+		TargetTeamSlug         func(childComplexity int) int
 	}
 
 	ServiceAccount struct {
@@ -646,12 +647,19 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Role.Name(childComplexity), true
 
-	case "Role.targetId":
-		if e.complexity.Role.TargetID == nil {
+	case "Role.targetServiceAccountID":
+		if e.complexity.Role.TargetServiceAccountID == nil {
 			break
 		}
 
-		return e.complexity.Role.TargetID(childComplexity), true
+		return e.complexity.Role.TargetServiceAccountID(childComplexity), true
+
+	case "Role.targetTeamSlug":
+		if e.complexity.Role.TargetTeamSlug == nil {
+			break
+		}
+
+		return e.complexity.Role.TargetTeamSlug(childComplexity), true
 
 	case "ServiceAccount.id":
 		if e.complexity.ServiceAccount.ID == nil {
@@ -1069,8 +1077,11 @@ type Role {
     "Whether or not the role is global."
     isGlobal: Boolean!
 
-    "Optional target of the role binding."
-    targetId: UUID
+    "Optional service account ID if the role binding targets a service account."
+    targetServiceAccountID: UUID
+
+    "Optional team slug if the role binding targets a team."
+    targetTeamSlug: Slug
 }`, BuiltIn: false},
 	{Name: "../../../graphql/scalars.graphqls", Input: `"Scalar value representing a UUID based on RFC 4122."
 scalar UUID
@@ -4809,8 +4820,8 @@ func (ec *executionContext) fieldContext_Role_isGlobal(ctx context.Context, fiel
 	return fc, nil
 }
 
-func (ec *executionContext) _Role_targetId(ctx context.Context, field graphql.CollectedField, obj *db.Role) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Role_targetId(ctx, field)
+func (ec *executionContext) _Role_targetServiceAccountID(ctx context.Context, field graphql.CollectedField, obj *db.Role) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Role_targetServiceAccountID(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -4823,7 +4834,7 @@ func (ec *executionContext) _Role_targetId(ctx context.Context, field graphql.Co
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.TargetID, nil
+		return obj.TargetServiceAccountID, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -4837,7 +4848,7 @@ func (ec *executionContext) _Role_targetId(ctx context.Context, field graphql.Co
 	return ec.marshalOUUID2ᚖgithubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Role_targetId(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Role_targetServiceAccountID(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Role",
 		Field:      field,
@@ -4845,6 +4856,47 @@ func (ec *executionContext) fieldContext_Role_targetId(ctx context.Context, fiel
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type UUID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Role_targetTeamSlug(ctx context.Context, field graphql.CollectedField, obj *db.Role) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Role_targetTeamSlug(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TargetTeamSlug, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*slug.Slug)
+	fc.Result = res
+	return ec.marshalOSlug2ᚖgithubᚗcomᚋnaisᚋconsoleᚋpkgᚋslugᚐSlug(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Role_targetTeamSlug(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Role",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Slug does not have child fields")
 		},
 	}
 	return fc, nil
@@ -4981,8 +5033,10 @@ func (ec *executionContext) fieldContext_ServiceAccount_roles(ctx context.Contex
 				return ec.fieldContext_Role_name(ctx, field)
 			case "isGlobal":
 				return ec.fieldContext_Role_isGlobal(ctx, field)
-			case "targetId":
-				return ec.fieldContext_Role_targetId(ctx, field)
+			case "targetServiceAccountID":
+				return ec.fieldContext_Role_targetServiceAccountID(ctx, field)
+			case "targetTeamSlug":
+				return ec.fieldContext_Role_targetTeamSlug(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Role", field.Name)
 		},
@@ -6136,8 +6190,10 @@ func (ec *executionContext) fieldContext_User_roles(ctx context.Context, field g
 				return ec.fieldContext_Role_name(ctx, field)
 			case "isGlobal":
 				return ec.fieldContext_Role_isGlobal(ctx, field)
-			case "targetId":
-				return ec.fieldContext_Role_targetId(ctx, field)
+			case "targetServiceAccountID":
+				return ec.fieldContext_Role_targetServiceAccountID(ctx, field)
+			case "targetTeamSlug":
+				return ec.fieldContext_Role_targetTeamSlug(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Role", field.Name)
 		},
@@ -8894,9 +8950,13 @@ func (ec *executionContext) _Role(ctx context.Context, sel ast.SelectionSet, obj
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)
 			}
-		case "targetId":
+		case "targetServiceAccountID":
 
-			out.Values[i] = ec._Role_targetId(ctx, field, obj)
+			out.Values[i] = ec._Role_targetServiceAccountID(ctx, field, obj)
+
+		case "targetTeamSlug":
+
+			out.Values[i] = ec._Role_targetTeamSlug(ctx, field, obj)
 
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
@@ -10878,6 +10938,22 @@ func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast
 		return graphql.Null
 	}
 	res := graphql.MarshalBoolean(*v)
+	return res
+}
+
+func (ec *executionContext) unmarshalOSlug2ᚖgithubᚗcomᚋnaisᚋconsoleᚋpkgᚋslugᚐSlug(ctx context.Context, v interface{}) (*slug.Slug, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := slug.UnmarshalSlug(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOSlug2ᚖgithubᚗcomᚋnaisᚋconsoleᚋpkgᚋslugᚐSlug(ctx context.Context, sel ast.SelectionSet, v *slug.Slug) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	res := slug.MarshalSlug(v)
 	return res
 }
 

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -71,21 +71,19 @@ type ComplexityRoot struct {
 	}
 
 	Mutation struct {
-		AddTeamMembers           func(childComplexity int, input model.AddTeamMembersInput) int
-		AddTeamOwners            func(childComplexity int, input model.AddTeamOwnersInput) int
-		AssignGlobalRoleToUser   func(childComplexity int, role sqlc.RoleName, userID *uuid.UUID) int
-		ConfigureReconciler      func(childComplexity int, name sqlc.ReconcilerName, config []*model.ReconcilerConfigInput) int
-		CreateTeam               func(childComplexity int, input model.CreateTeamInput) int
-		DisableReconciler        func(childComplexity int, name sqlc.ReconcilerName) int
-		DisableTeam              func(childComplexity int, teamID *uuid.UUID) int
-		EnableReconciler         func(childComplexity int, name sqlc.ReconcilerName) int
-		EnableTeam               func(childComplexity int, teamID *uuid.UUID) int
-		RemoveUsersFromTeam      func(childComplexity int, input model.RemoveUsersFromTeamInput) int
-		ResetReconciler          func(childComplexity int, name sqlc.ReconcilerName) int
-		RevokeGlobalRoleFromUser func(childComplexity int, role sqlc.RoleName, userID *uuid.UUID) int
-		SetTeamMemberRole        func(childComplexity int, input model.SetTeamMemberRoleInput) int
-		SynchronizeTeam          func(childComplexity int, teamID *uuid.UUID) int
-		UpdateTeam               func(childComplexity int, teamID *uuid.UUID, input model.UpdateTeamInput) int
+		AddTeamMembers      func(childComplexity int, input model.AddTeamMembersInput) int
+		AddTeamOwners       func(childComplexity int, input model.AddTeamOwnersInput) int
+		ConfigureReconciler func(childComplexity int, name sqlc.ReconcilerName, config []*model.ReconcilerConfigInput) int
+		CreateTeam          func(childComplexity int, input model.CreateTeamInput) int
+		DisableReconciler   func(childComplexity int, name sqlc.ReconcilerName) int
+		DisableTeam         func(childComplexity int, teamID *uuid.UUID) int
+		EnableReconciler    func(childComplexity int, name sqlc.ReconcilerName) int
+		EnableTeam          func(childComplexity int, teamID *uuid.UUID) int
+		RemoveUsersFromTeam func(childComplexity int, input model.RemoveUsersFromTeamInput) int
+		ResetReconciler     func(childComplexity int, name sqlc.ReconcilerName) int
+		SetTeamMemberRole   func(childComplexity int, input model.SetTeamMemberRoleInput) int
+		SynchronizeTeam     func(childComplexity int, teamID *uuid.UUID) int
+		UpdateTeam          func(childComplexity int, teamID *uuid.UUID, input model.UpdateTeamInput) int
 	}
 
 	Query struct {
@@ -185,8 +183,6 @@ type MutationResolver interface {
 	DisableReconciler(ctx context.Context, name sqlc.ReconcilerName) (*db.Reconciler, error)
 	ConfigureReconciler(ctx context.Context, name sqlc.ReconcilerName, config []*model.ReconcilerConfigInput) (*db.Reconciler, error)
 	ResetReconciler(ctx context.Context, name sqlc.ReconcilerName) (*db.Reconciler, error)
-	AssignGlobalRoleToUser(ctx context.Context, role sqlc.RoleName, userID *uuid.UUID) (*db.User, error)
-	RevokeGlobalRoleFromUser(ctx context.Context, role sqlc.RoleName, userID *uuid.UUID) (*db.User, error)
 	CreateTeam(ctx context.Context, input model.CreateTeamInput) (*db.Team, error)
 	UpdateTeam(ctx context.Context, teamID *uuid.UUID, input model.UpdateTeamInput) (*db.Team, error)
 	RemoveUsersFromTeam(ctx context.Context, input model.RemoveUsersFromTeamInput) (*db.Team, error)
@@ -335,18 +331,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Mutation.AddTeamOwners(childComplexity, args["input"].(model.AddTeamOwnersInput)), true
 
-	case "Mutation.assignGlobalRoleToUser":
-		if e.complexity.Mutation.AssignGlobalRoleToUser == nil {
-			break
-		}
-
-		args, err := ec.field_Mutation_assignGlobalRoleToUser_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Mutation.AssignGlobalRoleToUser(childComplexity, args["role"].(sqlc.RoleName), args["userID"].(*uuid.UUID)), true
-
 	case "Mutation.configureReconciler":
 		if e.complexity.Mutation.ConfigureReconciler == nil {
 			break
@@ -442,18 +426,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.ResetReconciler(childComplexity, args["name"].(sqlc.ReconcilerName)), true
-
-	case "Mutation.revokeGlobalRoleFromUser":
-		if e.complexity.Mutation.RevokeGlobalRoleFromUser == nil {
-			break
-		}
-
-		args, err := ec.field_Mutation_revokeGlobalRoleFromUser_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Mutation.RevokeGlobalRoleFromUser(childComplexity, args["role"].(sqlc.RoleName), args["userID"].(*uuid.UUID)), true
 
 	case "Mutation.setTeamMemberRole":
 		if e.complexity.Mutation.SetTeamMemberRole == nil {
@@ -1089,38 +1061,6 @@ input ReconcilerConfigInput {
     roles: [RoleName!]!
 }
 
-extend type Mutation {
-    """
-    Assign a global role to a user
-
-    Only users with the admin role are allowed to assign global roles.
-
-    The updated user is returned on success.
-    """
-    assignGlobalRoleToUser(
-        "The role to assign the user."
-        role: RoleName!
-
-        "The user that will be assiged the role."
-        userID: UUID!
-    ): User! @admin
-
-    """
-    Revoke a global role from a user
-
-    Only users with the admin role are allowed to revoke global roles.
-
-    The updated user is returned on success.
-    """
-    revokeGlobalRoleFromUser(
-        "The role to revoke from the user."
-        role: RoleName!
-
-        "The user to revoke the role from."
-        userID: UUID!
-    ): User! @admin
-}
-
 "Role binding type."
 type Role {
     "Name of the role."
@@ -1519,30 +1459,6 @@ func (ec *executionContext) field_Mutation_addTeamOwners_args(ctx context.Contex
 	return args, nil
 }
 
-func (ec *executionContext) field_Mutation_assignGlobalRoleToUser_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
-	var err error
-	args := map[string]interface{}{}
-	var arg0 sqlc.RoleName
-	if tmp, ok := rawArgs["role"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("role"))
-		arg0, err = ec.unmarshalNRoleName2githubᚗcomᚋnaisᚋconsoleᚋpkgᚋsqlcᚐRoleName(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["role"] = arg0
-	var arg1 *uuid.UUID
-	if tmp, ok := rawArgs["userID"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("userID"))
-		arg1, err = ec.unmarshalNUUID2ᚖgithubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["userID"] = arg1
-	return args, nil
-}
-
 func (ec *executionContext) field_Mutation_configureReconciler_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
@@ -1669,30 +1585,6 @@ func (ec *executionContext) field_Mutation_resetReconciler_args(ctx context.Cont
 		}
 	}
 	args["name"] = arg0
-	return args, nil
-}
-
-func (ec *executionContext) field_Mutation_revokeGlobalRoleFromUser_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
-	var err error
-	args := map[string]interface{}{}
-	var arg0 sqlc.RoleName
-	if tmp, ok := rawArgs["role"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("role"))
-		arg0, err = ec.unmarshalNRoleName2githubᚗcomᚋnaisᚋconsoleᚋpkgᚋsqlcᚐRoleName(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["role"] = arg0
-	var arg1 *uuid.UUID
-	if tmp, ok := rawArgs["userID"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("userID"))
-		arg1, err = ec.unmarshalNUUID2ᚖgithubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["userID"] = arg1
 	return args, nil
 }
 
@@ -2607,180 +2499,6 @@ func (ec *executionContext) fieldContext_Mutation_resetReconciler(ctx context.Co
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_resetReconciler_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Mutation_assignGlobalRoleToUser(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Mutation_assignGlobalRoleToUser(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		directive0 := func(rctx context.Context) (interface{}, error) {
-			ctx = rctx // use context from middleware stack in children
-			return ec.resolvers.Mutation().AssignGlobalRoleToUser(rctx, fc.Args["role"].(sqlc.RoleName), fc.Args["userID"].(*uuid.UUID))
-		}
-		directive1 := func(ctx context.Context) (interface{}, error) {
-			if ec.directives.Admin == nil {
-				return nil, errors.New("directive admin is not implemented")
-			}
-			return ec.directives.Admin(ctx, nil, directive0)
-		}
-
-		tmp, err := directive1(rctx)
-		if err != nil {
-			return nil, graphql.ErrorOnPath(ctx, err)
-		}
-		if tmp == nil {
-			return nil, nil
-		}
-		if data, ok := tmp.(*db.User); ok {
-			return data, nil
-		}
-		return nil, fmt.Errorf(`unexpected type %T from directive, should be *github.com/nais/console/pkg/db.User`, tmp)
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*db.User)
-	fc.Result = res
-	return ec.marshalNUser2ᚖgithubᚗcomᚋnaisᚋconsoleᚋpkgᚋdbᚐUser(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Mutation_assignGlobalRoleToUser(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Mutation",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_User_id(ctx, field)
-			case "email":
-				return ec.fieldContext_User_email(ctx, field)
-			case "name":
-				return ec.fieldContext_User_name(ctx, field)
-			case "teams":
-				return ec.fieldContext_User_teams(ctx, field)
-			case "roles":
-				return ec.fieldContext_User_roles(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Mutation_assignGlobalRoleToUser_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Mutation_revokeGlobalRoleFromUser(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Mutation_revokeGlobalRoleFromUser(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		directive0 := func(rctx context.Context) (interface{}, error) {
-			ctx = rctx // use context from middleware stack in children
-			return ec.resolvers.Mutation().RevokeGlobalRoleFromUser(rctx, fc.Args["role"].(sqlc.RoleName), fc.Args["userID"].(*uuid.UUID))
-		}
-		directive1 := func(ctx context.Context) (interface{}, error) {
-			if ec.directives.Admin == nil {
-				return nil, errors.New("directive admin is not implemented")
-			}
-			return ec.directives.Admin(ctx, nil, directive0)
-		}
-
-		tmp, err := directive1(rctx)
-		if err != nil {
-			return nil, graphql.ErrorOnPath(ctx, err)
-		}
-		if tmp == nil {
-			return nil, nil
-		}
-		if data, ok := tmp.(*db.User); ok {
-			return data, nil
-		}
-		return nil, fmt.Errorf(`unexpected type %T from directive, should be *github.com/nais/console/pkg/db.User`, tmp)
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*db.User)
-	fc.Result = res
-	return ec.marshalNUser2ᚖgithubᚗcomᚋnaisᚋconsoleᚋpkgᚋdbᚐUser(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Mutation_revokeGlobalRoleFromUser(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Mutation",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_User_id(ctx, field)
-			case "email":
-				return ec.fieldContext_User_email(ctx, field)
-			case "name":
-				return ec.fieldContext_User_name(ctx, field)
-			case "teams":
-				return ec.fieldContext_User_teams(ctx, field)
-			case "roles":
-				return ec.fieldContext_User_roles(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Mutation_revokeGlobalRoleFromUser_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return
 	}
@@ -8627,24 +8345,6 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_resetReconciler(ctx, field)
-			})
-
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		case "assignGlobalRoleToUser":
-
-			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._Mutation_assignGlobalRoleToUser(ctx, field)
-			})
-
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		case "revokeGlobalRoleFromUser":
-
-			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._Mutation_revokeGlobalRoleFromUser(ctx, field)
 			})
 
 			if out.Values[i] == graphql.Null {

--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -16,16 +16,16 @@ import (
 
 // Input for adding users to a team as members.
 type AddTeamMembersInput struct {
-	// ID of the team that should receive new members.
-	TeamID *uuid.UUID `json:"teamId"`
+	// Slug of the team that should receive new members.
+	Slug *slug.Slug `json:"slug"`
 	// List of user IDs that should be added to the team as members.
 	UserIds []*uuid.UUID `json:"userIds"`
 }
 
 // Input for adding users to a team as owners.
 type AddTeamOwnersInput struct {
-	// ID of the team that should receive new owners.
-	TeamID *uuid.UUID `json:"teamId"`
+	// Slug of the team that should receive new owners.
+	Slug *slug.Slug `json:"slug"`
 	// List of user IDs that should be added to the team as owners.
 	UserIds []*uuid.UUID `json:"userIds"`
 }
@@ -48,16 +48,16 @@ type ReconcilerConfigInput struct {
 
 // Input for removing users from a team.
 type RemoveUsersFromTeamInput struct {
+	// Team slug that users should be removed from.
+	Slug *slug.Slug `json:"slug"`
 	// List of user IDs that should be removed from the team.
 	UserIds []*uuid.UUID `json:"userIds"`
-	// Team ID that users should be removed from.
-	TeamID *uuid.UUID `json:"teamId"`
 }
 
 // Input for setting team member role.
 type SetTeamMemberRoleInput struct {
-	// The ID of the team.
-	TeamID *uuid.UUID `json:"teamId"`
+	// The slug of the team.
+	Slug *slug.Slug `json:"slug"`
 	// The ID of the user.
 	UserID *uuid.UUID `json:"userId"`
 	// The team role to set.

--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -14,22 +14,6 @@ import (
 	"github.com/nais/console/pkg/sqlc"
 )
 
-// Input for adding users to a team as members.
-type AddTeamMembersInput struct {
-	// Slug of the team that should receive new members.
-	Slug *slug.Slug `json:"slug"`
-	// List of user IDs that should be added to the team as members.
-	UserIds []*uuid.UUID `json:"userIds"`
-}
-
-// Input for adding users to a team as owners.
-type AddTeamOwnersInput struct {
-	// Slug of the team that should receive new owners.
-	Slug *slug.Slug `json:"slug"`
-	// List of user IDs that should be added to the team as owners.
-	UserIds []*uuid.UUID `json:"userIds"`
-}
-
 // Input for creating a new team.
 type CreateTeamInput struct {
 	// Team slug. After creation, this value can not be changed.
@@ -44,24 +28,6 @@ type ReconcilerConfigInput struct {
 	Key sqlc.ReconcilerConfigKey `json:"key"`
 	// Configuration value.
 	Value string `json:"value"`
-}
-
-// Input for removing users from a team.
-type RemoveUsersFromTeamInput struct {
-	// Team slug that users should be removed from.
-	Slug *slug.Slug `json:"slug"`
-	// List of user IDs that should be removed from the team.
-	UserIds []*uuid.UUID `json:"userIds"`
-}
-
-// Input for setting team member role.
-type SetTeamMemberRoleInput struct {
-	// The slug of the team.
-	Slug *slug.Slug `json:"slug"`
-	// The ID of the user.
-	UserID *uuid.UUID `json:"userId"`
-	// The team role to set.
-	Role TeamRole `json:"role"`
 }
 
 // Sync error type.

--- a/pkg/graph/reconcilers.go
+++ b/pkg/graph/reconcilers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nais/console/pkg/auditlogger"
 	"github.com/nais/console/pkg/authz"
 	"github.com/nais/console/pkg/db"
+	"github.com/nais/console/pkg/graph/apierror"
 	"github.com/nais/console/pkg/graph/generated"
 	"github.com/nais/console/pkg/graph/model"
 	"github.com/nais/console/pkg/sqlc"
@@ -19,7 +20,7 @@ import (
 // EnableReconciler is the resolver for the enableReconciler field.
 func (r *mutationResolver) EnableReconciler(ctx context.Context, name sqlc.ReconcilerName) (*db.Reconciler, error) {
 	if !name.Valid() {
-		return nil, fmt.Errorf("%q is not a valid name", name)
+		return nil, apierror.Errorf("%q is not a valid name", name)
 	}
 
 	var reconciler *db.Reconciler
@@ -73,7 +74,7 @@ func (r *mutationResolver) EnableReconciler(ctx context.Context, name sqlc.Recon
 // DisableReconciler is the resolver for the disableReconciler field.
 func (r *mutationResolver) DisableReconciler(ctx context.Context, name sqlc.ReconcilerName) (*db.Reconciler, error) {
 	if !name.Valid() {
-		return nil, fmt.Errorf("%q is not a valid name", name)
+		return nil, apierror.Errorf("%q is not a valid name", name)
 	}
 
 	var reconciler *db.Reconciler
@@ -111,7 +112,7 @@ func (r *mutationResolver) DisableReconciler(ctx context.Context, name sqlc.Reco
 // ConfigureReconciler is the resolver for the configureReconciler field.
 func (r *mutationResolver) ConfigureReconciler(ctx context.Context, name sqlc.ReconcilerName, config []*model.ReconcilerConfigInput) (*db.Reconciler, error) {
 	if !name.Valid() {
-		return nil, fmt.Errorf("%q is not a valid name", name)
+		return nil, apierror.Errorf("%q is not a valid name", name)
 	}
 
 	reconcilerConfig := make(map[sqlc.ReconcilerConfigKey]string)

--- a/pkg/graph/roles.go
+++ b/pkg/graph/roles.go
@@ -5,73 +5,11 @@ package graph
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/google/uuid"
-	"github.com/nais/console/pkg/auditlogger"
-	"github.com/nais/console/pkg/authz"
 	"github.com/nais/console/pkg/db"
 	"github.com/nais/console/pkg/graph/generated"
 	"github.com/nais/console/pkg/sqlc"
 )
-
-// AssignGlobalRoleToUser is the resolver for the assignGlobalRoleToUser field.
-func (r *mutationResolver) AssignGlobalRoleToUser(ctx context.Context, role sqlc.RoleName, userID *uuid.UUID) (*db.User, error) {
-	if !role.Valid() {
-		return nil, fmt.Errorf("%q is not a valid role", role)
-	}
-
-	user, err := r.database.GetUserByID(ctx, *userID)
-	if err != nil {
-		return nil, err
-	}
-
-	err = r.database.AssignGlobalRoleToUser(ctx, *userID, role)
-	if err != nil {
-		return nil, err
-	}
-
-	actor := authz.ActorFromContext(ctx)
-	targets := []auditlogger.Target{
-		auditlogger.UserTarget(user.Email),
-	}
-	fields := auditlogger.Fields{
-		Action: sqlc.AuditActionGraphqlApiRolesAssignGlobalRole,
-		Actor:  actor,
-	}
-	r.auditLogger.Logf(ctx, targets, fields, "Assign global role %q to user", role)
-
-	return user, nil
-}
-
-// RevokeGlobalRoleFromUser is the resolver for the revokeGlobalRoleFromUser field.
-func (r *mutationResolver) RevokeGlobalRoleFromUser(ctx context.Context, role sqlc.RoleName, userID *uuid.UUID) (*db.User, error) {
-	if !role.Valid() {
-		return nil, fmt.Errorf("%q is not a valid role", role)
-	}
-
-	user, err := r.database.GetUserByID(ctx, *userID)
-	if err != nil {
-		return nil, err
-	}
-
-	err = r.database.RevokeGlobalRoleFromUser(ctx, *userID, role)
-	if err != nil {
-		return nil, err
-	}
-
-	actor := authz.ActorFromContext(ctx)
-	targets := []auditlogger.Target{
-		auditlogger.UserTarget(user.Email),
-	}
-	fields := auditlogger.Fields{
-		Action: sqlc.AuditActionGraphqlApiRolesRevokeGlobalRole,
-		Actor:  actor,
-	}
-	r.auditLogger.Logf(ctx, targets, fields, "Revoke global role %q from user", role)
-
-	return user, nil
-}
 
 // Roles is the resolver for the roles field.
 func (r *queryResolver) Roles(ctx context.Context) ([]sqlc.RoleName, error) {

--- a/pkg/graph/serviceAccounts.go
+++ b/pkg/graph/serviceAccounts.go
@@ -15,12 +15,12 @@ import (
 // Roles is the resolver for the roles field.
 func (r *serviceAccountResolver) Roles(ctx context.Context, obj *db.ServiceAccount) ([]*db.Role, error) {
 	actor := authz.ActorFromContext(ctx)
-	err := authz.RequireAuthorizationOrTargetMatch(actor, sqlc.AuthzNameUsersUpdate, obj.ID)
-	if err != nil {
+	err := authz.RequireRole(actor, sqlc.RoleNameAdmin)
+	if err != nil && actor.User.GetID() != obj.ID {
 		return nil, err
 	}
 
-	return r.database.GetUserRoles(ctx, obj.ID)
+	return r.database.GetServiceAccountRoles(ctx, obj.ID)
 }
 
 // ServiceAccount returns generated.ServiceAccountResolver implementation.

--- a/pkg/graph/teams.go
+++ b/pkg/graph/teams.go
@@ -548,7 +548,7 @@ func (r *teamResolver) SyncErrors(ctx context.Context, obj *db.Team) ([]*model.S
 		return nil, err
 	}
 
-	rows, err := r.database.GetTeamReconcilerErrors(ctx, obj.ID)
+	rows, err := r.database.GetTeamReconcilerErrors(ctx, obj.Slug)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/graph/teams.go
+++ b/pkg/graph/teams.go
@@ -6,6 +6,7 @@ package graph
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/nais/console/pkg/auditlogger"
@@ -588,6 +589,14 @@ func (r *teamResolver) SyncErrors(ctx context.Context, obj *db.Team) ([]*model.S
 	}
 
 	return syncErrors, nil
+}
+
+// LastSuccessfulSync is the resolver for the lastSuccessfulSync field.
+func (r *teamResolver) LastSuccessfulSync(ctx context.Context, obj *db.Team) (*time.Time, error) {
+	if !obj.LastSuccessfulSync.Valid {
+		return nil, nil
+	}
+	return &obj.LastSuccessfulSync.Time, nil
 }
 
 // Team returns generated.TeamResolver implementation.

--- a/pkg/graph/teams.go
+++ b/pkg/graph/teams.go
@@ -488,7 +488,7 @@ func (r *teamResolver) Metadata(ctx context.Context, obj *db.Team) ([]*db.TeamMe
 		return nil, err
 	}
 
-	metadata, err := r.database.GetTeamMetadata(ctx, obj.ID)
+	metadata, err := r.database.GetTeamMetadata(ctx, obj.Slug)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/graph/teams.go
+++ b/pkg/graph/teams.go
@@ -101,7 +101,7 @@ func (r *mutationResolver) UpdateTeam(ctx context.Context, slug *slug.Slug, inpu
 		return nil, fmt.Errorf("create log correlation ID: %w", err)
 	}
 
-	team, err = r.database.UpdateTeam(ctx, team.ID, input.Purpose)
+	team, err = r.database.UpdateTeam(ctx, team.Slug, input.Purpose)
 	if err != nil {
 		return nil, err
 	}
@@ -418,7 +418,7 @@ func (r *mutationResolver) DisableTeam(ctx context.Context, slug *slug.Slug) (*d
 		return nil, fmt.Errorf("create log correlation ID: %w", err)
 	}
 
-	team, err = r.database.DisableTeam(ctx, team.ID)
+	team, err = r.database.DisableTeam(ctx, team.Slug)
 	if err != nil {
 		return nil, fmt.Errorf("disable team: %w", err)
 	}
@@ -457,7 +457,7 @@ func (r *mutationResolver) EnableTeam(ctx context.Context, slug *slug.Slug) (*db
 		return nil, fmt.Errorf("create log correlation ID: %w", err)
 	}
 
-	team, err = r.database.EnableTeam(ctx, team.ID)
+	team, err = r.database.EnableTeam(ctx, team.Slug)
 	if err != nil {
 		return nil, fmt.Errorf("enable team: %w", err)
 	}

--- a/pkg/graph/teams_test.go
+++ b/pkg/graph/teams_test.go
@@ -49,7 +49,7 @@ func TestMutationResolver_CreateTeam(t *testing.T) {
 
 	t.Run("create team", func(t *testing.T) {
 		createdTeam := &db.Team{
-			Team: &sqlc.Team{Slug: teamSlug, ID: uuid.New()},
+			Team: &sqlc.Team{Slug: teamSlug},
 		}
 		txCtx := context.Background()
 		dbtx := db.NewMockDatabase(t)
@@ -90,9 +90,9 @@ func TestMutationResolver_CreateTeam(t *testing.T) {
 			Purpose: " some purpose ",
 		})
 		assert.NoError(t, err)
-		assert.Equal(t, createdTeam.ID, returnedTeam.ID)
+		assert.Equal(t, createdTeam.Slug, returnedTeam.Slug)
 
 		input := <-reconcilers
-		assert.Equal(t, createdTeam.ID, input.Team.ID)
+		assert.Equal(t, createdTeam.Slug, input.Team.Slug)
 	})
 }

--- a/pkg/graph/teams_test.go
+++ b/pkg/graph/teams_test.go
@@ -59,7 +59,7 @@ func TestMutationResolver_CreateTeam(t *testing.T) {
 			Return(createdTeam, nil).
 			Once()
 		dbtx.
-			On("SetTeamMemberRole", txCtx, user.ID, createdTeam.ID, sqlc.RoleNameTeamowner).
+			On("SetTeamMemberRole", txCtx, user.ID, createdTeam.Slug, sqlc.RoleNameTeamowner).
 			Return(nil).
 			Once()
 
@@ -72,7 +72,7 @@ func TestMutationResolver_CreateTeam(t *testing.T) {
 			Return(nil).
 			Once()
 		database.
-			On("GetTeamMembers", ctx, createdTeam.ID).
+			On("GetTeamMembers", ctx, createdTeam.Slug).
 			Return([]*db.User{&user}, nil).
 			Once()
 

--- a/pkg/graph/users.go
+++ b/pkg/graph/users.go
@@ -62,7 +62,7 @@ func (r *userResolver) Teams(ctx context.Context, obj *db.User) ([]*model.TeamMe
 
 	userTeams := make([]*model.TeamMembership, 0, len(teams))
 	for _, team := range teams {
-		isOwner, err := r.database.UserIsTeamOwner(ctx, obj.ID, team.ID)
+		isOwner, err := r.database.UserIsTeamOwner(ctx, obj.ID, team.Slug)
 		if err != nil {
 			return nil, err
 		}
@@ -84,8 +84,8 @@ func (r *userResolver) Teams(ctx context.Context, obj *db.User) ([]*model.TeamMe
 // Roles is the resolver for the roles field.
 func (r *userResolver) Roles(ctx context.Context, obj *db.User) ([]*db.Role, error) {
 	actor := authz.ActorFromContext(ctx)
-	err := authz.RequireAuthorizationOrTargetMatch(actor, sqlc.AuthzNameUsersUpdate, obj.ID)
-	if err != nil {
+	err := authz.RequireRole(actor, sqlc.RoleNameAdmin)
+	if err != nil && actor.User.GetID() != obj.ID {
 		return nil, err
 	}
 

--- a/pkg/reconcilers/azure/group/reconciler.go
+++ b/pkg/reconcilers/azure/group/reconciler.go
@@ -83,7 +83,7 @@ func (r *azureGroupReconciler) Name() sqlc.ReconcilerName {
 
 func (r *azureGroupReconciler) Reconcile(ctx context.Context, input reconcilers.Input) error {
 	state := &reconcilers.AzureState{}
-	err := r.database.LoadReconcilerStateForTeam(ctx, r.Name(), input.Team.ID, state)
+	err := r.database.LoadReconcilerStateForTeam(ctx, r.Name(), input.Team.Slug, state)
 	if err != nil {
 		return fmt.Errorf("unable to load system state for team %q in system %q: %w", input.Team.Slug, r.Name(), err)
 	}
@@ -105,7 +105,7 @@ func (r *azureGroupReconciler) Reconcile(ctx context.Context, input reconcilers.
 		r.auditLogger.Logf(ctx, targets, fields, "created Azure AD group: %s", grp)
 
 		id, _ := uuid.Parse(grp.ID)
-		err = r.database.SetReconcilerStateForTeam(ctx, r.Name(), input.Team.ID, reconcilers.AzureState{GroupID: &id})
+		err = r.database.SetReconcilerStateForTeam(ctx, r.Name(), input.Team.Slug, reconcilers.AzureState{GroupID: &id})
 		if err != nil {
 			log.Errorf("system state not persisted: %s", err)
 		}

--- a/pkg/reconcilers/azure/group/reconciler_test.go
+++ b/pkg/reconcilers/azure/group/reconciler_test.go
@@ -55,7 +55,6 @@ func TestAzureReconciler_Reconcile(t *testing.T) {
 	correlationID := uuid.New()
 	team := db.Team{
 		Team: &sqlc.Team{
-			ID:      uuid.New(),
 			Slug:    teamSlug,
 			Purpose: teamPurpose,
 		},
@@ -191,7 +190,6 @@ func TestAzureReconciler_Reconcile(t *testing.T) {
 
 		team := db.Team{
 			Team: &sqlc.Team{
-				ID:      uuid.New(),
 				Slug:    teamSlug,
 				Purpose: teamPurpose,
 			},

--- a/pkg/reconcilers/azure/group/reconciler_test.go
+++ b/pkg/reconcilers/azure/group/reconciler_test.go
@@ -76,11 +76,11 @@ func TestAzureReconciler_Reconcile(t *testing.T) {
 		reconciler := azure_group_reconciler.New(database, auditLogger, mockClient, domain)
 
 		database.
-			On("LoadReconcilerStateForTeam", ctx, azure_group_reconciler.Name, team.ID, mock.Anything).
+			On("LoadReconcilerStateForTeam", ctx, azure_group_reconciler.Name, team.Slug, mock.Anything).
 			Return(nil).
 			Once()
 		database.
-			On("SetReconcilerStateForTeam", ctx, azure_group_reconciler.Name, team.ID, mock.Anything).
+			On("SetReconcilerStateForTeam", ctx, azure_group_reconciler.Name, team.Slug, mock.Anything).
 			Return(nil).
 			Once()
 		database.
@@ -145,7 +145,7 @@ func TestAzureReconciler_Reconcile(t *testing.T) {
 		reconciler := azure_group_reconciler.New(database, auditLogger, mockClient, domain)
 
 		database.
-			On("LoadReconcilerStateForTeam", ctx, azure_group_reconciler.Name, team.ID, mock.Anything).
+			On("LoadReconcilerStateForTeam", ctx, azure_group_reconciler.Name, team.Slug, mock.Anything).
 			Return(nil).
 			Once()
 
@@ -165,7 +165,7 @@ func TestAzureReconciler_Reconcile(t *testing.T) {
 		reconciler := azure_group_reconciler.New(database, auditLogger, mockClient, domain)
 
 		database.
-			On("LoadReconcilerStateForTeam", ctx, azure_group_reconciler.Name, team.ID, mock.Anything).
+			On("LoadReconcilerStateForTeam", ctx, azure_group_reconciler.Name, team.Slug, mock.Anything).
 			Return(nil).
 			Once()
 
@@ -198,7 +198,7 @@ func TestAzureReconciler_Reconcile(t *testing.T) {
 		}
 
 		database.
-			On("LoadReconcilerStateForTeam", ctx, azure_group_reconciler.Name, team.ID, mock.Anything).
+			On("LoadReconcilerStateForTeam", ctx, azure_group_reconciler.Name, team.Slug, mock.Anything).
 			Return(nil).
 			Once()
 
@@ -235,7 +235,7 @@ func TestAzureReconciler_Reconcile(t *testing.T) {
 		reconciler := azure_group_reconciler.New(database, auditLogger, mockClient, domain)
 
 		database.
-			On("LoadReconcilerStateForTeam", ctx, azure_group_reconciler.Name, team.ID, mock.Anything).
+			On("LoadReconcilerStateForTeam", ctx, azure_group_reconciler.Name, team.Slug, mock.Anything).
 			Return(nil).
 			Once()
 		database.
@@ -285,7 +285,7 @@ func TestAzureReconciler_Reconcile(t *testing.T) {
 		reconciler := azure_group_reconciler.New(database, auditLogger, mockClient, domain)
 
 		database.
-			On("LoadReconcilerStateForTeam", ctx, azure_group_reconciler.Name, team.ID, mock.Anything).
+			On("LoadReconcilerStateForTeam", ctx, azure_group_reconciler.Name, team.Slug, mock.Anything).
 			Return(nil).
 			Once()
 

--- a/pkg/reconcilers/github/team/reconciler.go
+++ b/pkg/reconcilers/github/team/reconciler.go
@@ -72,7 +72,7 @@ func (r *githubTeamReconciler) Name() sqlc.ReconcilerName {
 
 func (r *githubTeamReconciler) Reconcile(ctx context.Context, input reconcilers.Input) error {
 	state := &reconcilers.GitHubState{}
-	err := r.database.LoadReconcilerStateForTeam(ctx, r.Name(), input.Team.ID, state)
+	err := r.database.LoadReconcilerStateForTeam(ctx, r.Name(), input.Team.Slug, state)
 	if err != nil {
 		return fmt.Errorf("unable to load system state for team %q in system %q: %w", input.Team.Slug, r.Name(), err)
 	}
@@ -93,7 +93,7 @@ func (r *githubTeamReconciler) Reconcile(ctx context.Context, input reconcilers.
 	}
 
 	slug := slug.Slug(*githubTeam.Slug)
-	err = r.database.SetReconcilerStateForTeam(ctx, r.Name(), input.Team.ID, reconcilers.GitHubState{Slug: &slug})
+	err = r.database.SetReconcilerStateForTeam(ctx, r.Name(), input.Team.Slug, reconcilers.GitHubState{Slug: &slug})
 	if err != nil {
 		log.Errorf("system state not persisted: %s", err)
 	}

--- a/pkg/reconcilers/github/team/reconciler_test.go
+++ b/pkg/reconcilers/github/team/reconciler_test.go
@@ -50,11 +50,11 @@ func TestGitHubReconciler_getOrCreateTeam(t *testing.T) {
 		gitHubClient := github_team_reconciler.NewMockGraphClient(t)
 
 		database.
-			On("LoadReconcilerStateForTeam", ctx, systemName, team.ID, mock.Anything).
+			On("LoadReconcilerStateForTeam", ctx, systemName, team.Slug, mock.Anything).
 			Return(nil).
 			Once()
 		database.
-			On("SetReconcilerStateForTeam", ctx, systemName, team.ID, mock.Anything).
+			On("SetReconcilerStateForTeam", ctx, systemName, team.Slug, mock.Anything).
 			Return(nil).
 			Once()
 
@@ -111,7 +111,7 @@ func TestGitHubReconciler_getOrCreateTeam(t *testing.T) {
 		gitHubClient := github_team_reconciler.NewMockGraphClient(t)
 
 		database.
-			On("LoadReconcilerStateForTeam", ctx, systemName, team.ID, mock.Anything).
+			On("LoadReconcilerStateForTeam", ctx, systemName, team.Slug, mock.Anything).
 			Return(nil).
 			Once()
 
@@ -141,7 +141,7 @@ func TestGitHubReconciler_getOrCreateTeam(t *testing.T) {
 		gitHubClient := github_team_reconciler.NewMockGraphClient(t)
 
 		database.
-			On("LoadReconcilerStateForTeam", ctx, systemName, team.ID, mock.Anything).
+			On("LoadReconcilerStateForTeam", ctx, systemName, team.Slug, mock.Anything).
 			Run(func(args mock.Arguments) {
 				slug := slug.Slug(teamSlug)
 				state := args.Get(3).(*reconcilers.GitHubState)
@@ -150,7 +150,7 @@ func TestGitHubReconciler_getOrCreateTeam(t *testing.T) {
 			Return(nil).
 			Once()
 		database.
-			On("SetReconcilerStateForTeam", ctx, systemName, team.ID, mock.MatchedBy(func(state reconcilers.GitHubState) bool {
+			On("SetReconcilerStateForTeam", ctx, systemName, team.Slug, mock.MatchedBy(func(state reconcilers.GitHubState) bool {
 				return string(*state.Slug) == teamSlug
 			})).
 			Return(nil).
@@ -200,7 +200,7 @@ func TestGitHubReconciler_getOrCreateTeam(t *testing.T) {
 		const existingSlug = "existing-slug"
 
 		database.
-			On("LoadReconcilerStateForTeam", ctx, systemName, team.ID, mock.Anything).
+			On("LoadReconcilerStateForTeam", ctx, systemName, team.Slug, mock.Anything).
 			Run(func(args mock.Arguments) {
 				slug := slug.Slug(existingSlug)
 				state := args.Get(3).(*reconcilers.GitHubState)
@@ -209,7 +209,7 @@ func TestGitHubReconciler_getOrCreateTeam(t *testing.T) {
 			Return(nil).
 			Once()
 		database.
-			On("SetReconcilerStateForTeam", ctx, systemName, team.ID, mock.MatchedBy(func(state reconcilers.GitHubState) bool {
+			On("SetReconcilerStateForTeam", ctx, systemName, team.Slug, mock.MatchedBy(func(state reconcilers.GitHubState) bool {
 				return *state.Slug == existingSlug
 			})).
 			Return(nil).
@@ -325,11 +325,11 @@ func TestGitHubReconciler_Reconcile(t *testing.T) {
 		graphClient := github_team_reconciler.NewMockGraphClient(t)
 
 		database.
-			On("LoadReconcilerStateForTeam", ctx, systemName, team.ID, mock.Anything).
+			On("LoadReconcilerStateForTeam", ctx, systemName, team.Slug, mock.Anything).
 			Return(nil).
 			Once()
 		database.
-			On("SetReconcilerStateForTeam", ctx, systemName, team.ID, mock.MatchedBy(func(state reconcilers.GitHubState) bool {
+			On("SetReconcilerStateForTeam", ctx, systemName, team.Slug, mock.MatchedBy(func(state reconcilers.GitHubState) bool {
 				return *state.Slug == teamSlug
 			})).
 			Return(nil).
@@ -364,7 +364,7 @@ func TestGitHubReconciler_Reconcile(t *testing.T) {
 		database := db.NewMockDatabase(t)
 
 		database.
-			On("LoadReconcilerStateForTeam", ctx, systemName, team.ID, mock.Anything).
+			On("LoadReconcilerStateForTeam", ctx, systemName, team.Slug, mock.Anything).
 			Run(func(args mock.Arguments) {
 				slug := slug.Slug("slug-from-state")
 				state := args.Get(3).(*reconcilers.GitHubState)

--- a/pkg/reconcilers/github/team/reconciler_test.go
+++ b/pkg/reconcilers/github/team/reconciler_test.go
@@ -32,7 +32,6 @@ func TestGitHubReconciler_getOrCreateTeam(t *testing.T) {
 	correlationID := uuid.New()
 	team := db.Team{
 		Team: &sqlc.Team{
-			ID:      uuid.New(),
 			Slug:    slug.Slug(teamSlug),
 			Purpose: teamPurpose,
 		},
@@ -295,7 +294,6 @@ func TestGitHubReconciler_Reconcile(t *testing.T) {
 
 	team := db.Team{
 		Team: &sqlc.Team{
-			ID:      uuid.New(),
 			Slug:    teamSlug,
 			Purpose: teamPurpose,
 		},

--- a/pkg/reconcilers/google/gcp/reconciler.go
+++ b/pkg/reconcilers/google/gcp/reconciler.go
@@ -67,13 +67,13 @@ func (r *googleGcpReconciler) Reconcile(ctx context.Context, input reconcilers.I
 	state := &reconcilers.GoogleGcpProjectState{
 		Projects: make(map[string]reconcilers.GoogleGcpEnvironmentProject),
 	}
-	err := r.database.LoadReconcilerStateForTeam(ctx, r.Name(), input.Team.ID, state)
+	err := r.database.LoadReconcilerStateForTeam(ctx, r.Name(), input.Team.Slug, state)
 	if err != nil {
 		return fmt.Errorf("load system state for team %q in system %q: %w", input.Team.Slug, r.Name(), err)
 	}
 
 	googleWorkspaceState := &reconcilers.GoogleWorkspaceState{}
-	err = r.database.LoadReconcilerStateForTeam(ctx, google_workspace_admin_reconciler.Name, input.Team.ID, googleWorkspaceState)
+	err = r.database.LoadReconcilerStateForTeam(ctx, google_workspace_admin_reconciler.Name, input.Team.Slug, googleWorkspaceState)
 	if err != nil {
 		return fmt.Errorf("load system state for team %q in system %q: %w", input.Team.Slug, google_workspace_admin_reconciler.Name, err)
 	}
@@ -91,7 +91,7 @@ func (r *googleGcpReconciler) Reconcile(ctx context.Context, input reconcilers.I
 			ProjectID: project.ProjectId,
 		}
 
-		err = r.database.SetReconcilerStateForTeam(ctx, r.Name(), input.Team.ID, state)
+		err = r.database.SetReconcilerStateForTeam(ctx, r.Name(), input.Team.Slug, state)
 		if err != nil {
 			log.Errorf("system state not persisted: %s", err)
 		}

--- a/pkg/reconcilers/google/gcp/reconciler_test.go
+++ b/pkg/reconcilers/google/gcp/reconciler_test.go
@@ -47,7 +47,7 @@ func TestReconcile(t *testing.T) {
 		auditLogger := auditlogger.NewMockAuditLogger(t)
 		database := db.NewMockDatabase(t)
 		database.
-			On("LoadReconcilerStateForTeam", ctx, google_gcp_reconciler.Name, team.ID, mock.Anything).
+			On("LoadReconcilerStateForTeam", ctx, google_gcp_reconciler.Name, team.Slug, mock.Anything).
 			Return(fmt.Errorf("some error")).
 			Once()
 		gcpServices := &google_gcp_reconciler.GcpServices{}
@@ -62,11 +62,11 @@ func TestReconcile(t *testing.T) {
 		auditLogger := auditlogger.NewMockAuditLogger(t)
 		database := db.NewMockDatabase(t)
 		database.
-			On("LoadReconcilerStateForTeam", ctx, google_gcp_reconciler.Name, team.ID, mock.Anything).
+			On("LoadReconcilerStateForTeam", ctx, google_gcp_reconciler.Name, team.Slug, mock.Anything).
 			Return(nil).
 			Once()
 		database.
-			On("LoadReconcilerStateForTeam", ctx, google_workspace_admin_reconciler.Name, team.ID, mock.Anything).
+			On("LoadReconcilerStateForTeam", ctx, google_workspace_admin_reconciler.Name, team.Slug, mock.Anything).
 			Return(fmt.Errorf("some error")).
 			Once()
 		gcpServices := &google_gcp_reconciler.GcpServices{}
@@ -81,11 +81,11 @@ func TestReconcile(t *testing.T) {
 		auditLogger := auditlogger.NewMockAuditLogger(t)
 		database := db.NewMockDatabase(t)
 		database.
-			On("LoadReconcilerStateForTeam", ctx, google_gcp_reconciler.Name, team.ID, mock.Anything).
+			On("LoadReconcilerStateForTeam", ctx, google_gcp_reconciler.Name, team.Slug, mock.Anything).
 			Return(nil).
 			Once()
 		database.
-			On("LoadReconcilerStateForTeam", ctx, google_workspace_admin_reconciler.Name, team.ID, mock.Anything).
+			On("LoadReconcilerStateForTeam", ctx, google_workspace_admin_reconciler.Name, team.Slug, mock.Anything).
 			Return(nil).
 			Once()
 		gcpServices := &google_gcp_reconciler.GcpServices{}
@@ -100,11 +100,11 @@ func TestReconcile(t *testing.T) {
 		auditLogger := auditlogger.NewMockAuditLogger(t)
 		database := db.NewMockDatabase(t)
 		database.
-			On("LoadReconcilerStateForTeam", ctx, google_gcp_reconciler.Name, team.ID, mock.Anything).
+			On("LoadReconcilerStateForTeam", ctx, google_gcp_reconciler.Name, team.Slug, mock.Anything).
 			Return(nil).
 			Once()
 		database.
-			On("LoadReconcilerStateForTeam", ctx, google_workspace_admin_reconciler.Name, team.ID, mock.Anything).
+			On("LoadReconcilerStateForTeam", ctx, google_workspace_admin_reconciler.Name, team.Slug, mock.Anything).
 			Run(func(args mock.Arguments) {
 				email := "mail@example.com"
 				state := args.Get(3).(*reconcilers.GoogleWorkspaceState)

--- a/pkg/reconcilers/google/gcp/reconciler_test.go
+++ b/pkg/reconcilers/google/gcp/reconciler_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/nais/console/pkg/slug"
+
 	"github.com/google/uuid"
 	"github.com/nais/console/pkg/auditlogger"
 	"github.com/nais/console/pkg/db"
@@ -34,9 +36,9 @@ func TestReconcile(t *testing.T) {
 		},
 	}
 
-	teamID := uuid.New()
+	teamSlug := slug.Slug("slug")
 	correlationID := uuid.New()
-	team := db.Team{Team: &sqlc.Team{ID: teamID}}
+	team := db.Team{Team: &sqlc.Team{Slug: teamSlug}}
 	input := reconcilers.Input{
 		CorrelationID: correlationID,
 		Team:          team,

--- a/pkg/reconcilers/google/workspace_admin/reconciler.go
+++ b/pkg/reconcilers/google/workspace_admin/reconciler.go
@@ -59,7 +59,7 @@ func (r *googleWorkspaceAdminReconciler) Name() sqlc.ReconcilerName {
 
 func (r *googleWorkspaceAdminReconciler) Reconcile(ctx context.Context, input reconcilers.Input) error {
 	state := &reconcilers.GoogleWorkspaceState{}
-	err := r.database.LoadReconcilerStateForTeam(ctx, r.Name(), input.Team.ID, state)
+	err := r.database.LoadReconcilerStateForTeam(ctx, r.Name(), input.Team.Slug, state)
 	if err != nil {
 		return fmt.Errorf("unable to load system state for team %q in system %q: %w", input.Team.Slug, r.Name(), err)
 	}
@@ -74,7 +74,7 @@ func (r *googleWorkspaceAdminReconciler) Reconcile(ctx context.Context, input re
 		return err
 	}
 
-	err = r.database.SetReconcilerStateForTeam(ctx, r.Name(), input.Team.ID, reconcilers.GoogleWorkspaceState{GroupEmail: &grp.Email})
+	err = r.database.SetReconcilerStateForTeam(ctx, r.Name(), input.Team.Slug, reconcilers.GoogleWorkspaceState{GroupEmail: &grp.Email})
 	if err != nil {
 		log.Errorf("system state not persisted: %s", err)
 	}

--- a/pkg/reconcilers/input.go
+++ b/pkg/reconcilers/input.go
@@ -21,7 +21,7 @@ func CreateReconcilerInput(ctx context.Context, database db.Database, team db.Te
 		return Input{}, err
 	}
 
-	members, err := database.GetTeamMembers(ctx, team.ID)
+	members, err := database.GetTeamMembers(ctx, team.Slug)
 	if err != nil {
 		return Input{}, err
 	}

--- a/pkg/reconcilers/nais/namespace/reconciler.go
+++ b/pkg/reconcilers/nais/namespace/reconciler.go
@@ -73,13 +73,13 @@ func (r *naisNamespaceReconciler) Reconcile(ctx context.Context, input reconcile
 	namespaceState := &reconcilers.GoogleGcpNaisNamespaceState{
 		Namespaces: make(map[string]slug.Slug),
 	}
-	err = r.database.LoadReconcilerStateForTeam(ctx, r.Name(), input.Team.ID, namespaceState)
+	err = r.database.LoadReconcilerStateForTeam(ctx, r.Name(), input.Team.Slug, namespaceState)
 	if err != nil {
 		return fmt.Errorf("unable to load system state for team %q in system %q: %w", input.Team.Slug, r.Name(), err)
 	}
 
 	gcpProjectState := &reconcilers.GoogleGcpProjectState{}
-	err = r.database.LoadReconcilerStateForTeam(ctx, google_gcp_reconciler.Name, input.Team.ID, gcpProjectState)
+	err = r.database.LoadReconcilerStateForTeam(ctx, google_gcp_reconciler.Name, input.Team.Slug, gcpProjectState)
 	if err != nil {
 		return fmt.Errorf("unable to load system state for team %q in system %q: %w", input.Team.Slug, google_gcp_reconciler.Name, err)
 	}
@@ -89,7 +89,7 @@ func (r *naisNamespaceReconciler) Reconcile(ctx context.Context, input reconcile
 	}
 
 	workspaceState := &reconcilers.GoogleWorkspaceState{}
-	err = r.database.LoadReconcilerStateForTeam(ctx, google_workspace_admin_reconciler.Name, input.Team.ID, workspaceState)
+	err = r.database.LoadReconcilerStateForTeam(ctx, google_workspace_admin_reconciler.Name, input.Team.Slug, workspaceState)
 	if err != nil || workspaceState.GroupEmail == nil {
 		return fmt.Errorf("no workspace admin state exists for team %q, or group email not set", input.Team.Slug)
 	}
@@ -113,7 +113,7 @@ func (r *naisNamespaceReconciler) Reconcile(ctx context.Context, input reconcile
 		}
 	}
 
-	err = r.database.SetReconcilerStateForTeam(ctx, r.Name(), input.Team.ID, namespaceState)
+	err = r.database.SetReconcilerStateForTeam(ctx, r.Name(), input.Team.Slug, namespaceState)
 	if err != nil {
 		log.Errorf("system state not persisted: %s", err)
 	}

--- a/pkg/sqlc/models.go
+++ b/pkg/sqlc/models.go
@@ -721,8 +721,8 @@ type ReconcilerError struct {
 
 type ReconcilerState struct {
 	Reconciler ReconcilerName
-	TeamID     uuid.UUID
 	State      pgtype.JSONB
+	TeamSlug   slug.Slug
 }
 
 type RoleAuthz struct {

--- a/pkg/sqlc/models.go
+++ b/pkg/sqlc/models.go
@@ -736,10 +736,11 @@ type ServiceAccount struct {
 }
 
 type ServiceAccountRole struct {
-	ID               int32
-	RoleName         RoleName
-	ServiceAccountID uuid.UUID
-	TargetID         uuid.NullUUID
+	ID                     int32
+	RoleName               RoleName
+	ServiceAccountID       uuid.UUID
+	TargetTeamSlug         *slug.Slug
+	TargetServiceAccountID uuid.NullUUID
 }
 
 type Session struct {
@@ -769,8 +770,9 @@ type User struct {
 }
 
 type UserRole struct {
-	ID       int32
-	RoleName RoleName
-	UserID   uuid.UUID
-	TargetID uuid.NullUUID
+	ID                     int32
+	RoleName               RoleName
+	UserID                 uuid.UUID
+	TargetTeamSlug         *slug.Slug
+	TargetServiceAccountID uuid.NullUUID
 }

--- a/pkg/sqlc/models.go
+++ b/pkg/sqlc/models.go
@@ -713,10 +713,10 @@ type ReconcilerConfig struct {
 type ReconcilerError struct {
 	ID            int64
 	CorrelationID uuid.UUID
-	TeamID        uuid.UUID
 	Reconciler    ReconcilerName
 	CreatedAt     time.Time
 	ErrorMessage  string
+	TeamSlug      slug.Slug
 }
 
 type ReconcilerState struct {

--- a/pkg/sqlc/models.go
+++ b/pkg/sqlc/models.go
@@ -750,9 +750,10 @@ type Session struct {
 }
 
 type Team struct {
-	Slug    slug.Slug
-	Purpose string
-	Enabled bool
+	Slug               slug.Slug
+	Purpose            string
+	Enabled            bool
+	LastSuccessfulSync sql.NullTime
 }
 
 type TeamMetadatum struct {

--- a/pkg/sqlc/models.go
+++ b/pkg/sqlc/models.go
@@ -756,9 +756,9 @@ type Team struct {
 }
 
 type TeamMetadatum struct {
-	TeamID uuid.UUID
-	Key    string
-	Value  sql.NullString
+	Key      string
+	Value    sql.NullString
+	TeamSlug slug.Slug
 }
 
 type User struct {

--- a/pkg/sqlc/models.go
+++ b/pkg/sqlc/models.go
@@ -750,7 +750,6 @@ type Session struct {
 }
 
 type Team struct {
-	ID      uuid.UUID
 	Slug    slug.Slug
 	Purpose string
 	Enabled bool

--- a/pkg/sqlc/querier.go
+++ b/pkg/sqlc/querier.go
@@ -47,7 +47,7 @@ type Querier interface {
 	GetTeamByID(ctx context.Context, id uuid.UUID) (*Team, error)
 	GetTeamBySlug(ctx context.Context, slug slug.Slug) (*Team, error)
 	GetTeamMembers(ctx context.Context, teamID uuid.UUID) ([]*User, error)
-	GetTeamMetadata(ctx context.Context, teamID uuid.UUID) ([]*TeamMetadatum, error)
+	GetTeamMetadata(ctx context.Context, teamSlug slug.Slug) ([]*TeamMetadatum, error)
 	GetTeamReconcilerErrors(ctx context.Context, teamID uuid.UUID) ([]*ReconcilerError, error)
 	GetTeams(ctx context.Context) ([]*Team, error)
 	GetUserByEmail(ctx context.Context, email string) (*User, error)

--- a/pkg/sqlc/querier.go
+++ b/pkg/sqlc/querier.go
@@ -28,9 +28,9 @@ type Querier interface {
 	DeleteSession(ctx context.Context, id uuid.UUID) error
 	DeleteUser(ctx context.Context, id uuid.UUID) error
 	DisableReconciler(ctx context.Context, name ReconcilerName) (*Reconciler, error)
-	DisableTeam(ctx context.Context, id uuid.UUID) (*Team, error)
+	DisableTeam(ctx context.Context, slug slug.Slug) (*Team, error)
 	EnableReconciler(ctx context.Context, name ReconcilerName) (*Reconciler, error)
-	EnableTeam(ctx context.Context, id uuid.UUID) (*Team, error)
+	EnableTeam(ctx context.Context, slug slug.Slug) (*Team, error)
 	GetAuditLogsForReconciler(ctx context.Context, targetIdentifier string) ([]*AuditLog, error)
 	GetAuditLogsForTeam(ctx context.Context, targetIdentifier string) ([]*AuditLog, error)
 	GetEnabledReconcilers(ctx context.Context) ([]*Reconciler, error)

--- a/pkg/sqlc/querier.go
+++ b/pkg/sqlc/querier.go
@@ -48,7 +48,7 @@ type Querier interface {
 	GetTeamBySlug(ctx context.Context, slug slug.Slug) (*Team, error)
 	GetTeamMembers(ctx context.Context, teamID uuid.UUID) ([]*User, error)
 	GetTeamMetadata(ctx context.Context, teamSlug slug.Slug) ([]*TeamMetadatum, error)
-	GetTeamReconcilerErrors(ctx context.Context, teamID uuid.UUID) ([]*ReconcilerError, error)
+	GetTeamReconcilerErrors(ctx context.Context, teamSlug slug.Slug) ([]*ReconcilerError, error)
 	GetTeams(ctx context.Context) ([]*Team, error)
 	GetUserByEmail(ctx context.Context, email string) (*User, error)
 	GetUserByExternalID(ctx context.Context, externalID string) (*User, error)

--- a/pkg/sqlc/querier.go
+++ b/pkg/sqlc/querier.go
@@ -14,7 +14,7 @@ import (
 type Querier interface {
 	AssignGlobalRoleToServiceAccount(ctx context.Context, arg AssignGlobalRoleToServiceAccountParams) error
 	AssignGlobalRoleToUser(ctx context.Context, arg AssignGlobalRoleToUserParams) error
-	AssignTargetedRoleToUser(ctx context.Context, arg AssignTargetedRoleToUserParams) error
+	AssignTeamRoleToUser(ctx context.Context, arg AssignTeamRoleToUserParams) error
 	ClearReconcilerErrorsForTeam(ctx context.Context, arg ClearReconcilerErrorsForTeamParams) error
 	ConfigureReconciler(ctx context.Context, arg ConfigureReconcilerParams) error
 	CreateAPIKey(ctx context.Context, arg CreateAPIKeyParams) error
@@ -46,7 +46,7 @@ type Querier interface {
 	GetSessionByID(ctx context.Context, id uuid.UUID) (*Session, error)
 	GetTeamByID(ctx context.Context, id uuid.UUID) (*Team, error)
 	GetTeamBySlug(ctx context.Context, slug slug.Slug) (*Team, error)
-	GetTeamMembers(ctx context.Context, teamID uuid.UUID) ([]*User, error)
+	GetTeamMembers(ctx context.Context, targetTeamSlug *slug.Slug) ([]*User, error)
 	GetTeamMetadata(ctx context.Context, teamSlug slug.Slug) ([]*TeamMetadatum, error)
 	GetTeamReconcilerErrors(ctx context.Context, teamSlug slug.Slug) ([]*ReconcilerError, error)
 	GetTeams(ctx context.Context) ([]*Team, error)
@@ -60,9 +60,8 @@ type Querier interface {
 	RemoveAllUserRoles(ctx context.Context, userID uuid.UUID) error
 	RemoveApiKeysFromServiceAccount(ctx context.Context, serviceAccountID uuid.UUID) error
 	RemoveGlobalUserRole(ctx context.Context, arg RemoveGlobalUserRoleParams) error
+	RemoveUserFromTeam(ctx context.Context, arg RemoveUserFromTeamParams) error
 	ResetReconcilerConfig(ctx context.Context, reconciler ReconcilerName) error
-	RevokeGlobalRoleFromUser(ctx context.Context, arg RevokeGlobalRoleFromUserParams) error
-	RevokeTargetedRoleFromUser(ctx context.Context, arg RevokeTargetedRoleFromUserParams) error
 	SetReconcilerErrorForTeam(ctx context.Context, arg SetReconcilerErrorForTeamParams) error
 	SetReconcilerStateForTeam(ctx context.Context, arg SetReconcilerStateForTeamParams) error
 	SetSessionExpires(ctx context.Context, arg SetSessionExpiresParams) (*Session, error)

--- a/pkg/sqlc/querier.go
+++ b/pkg/sqlc/querier.go
@@ -61,6 +61,7 @@ type Querier interface {
 	RemoveGlobalUserRole(ctx context.Context, arg RemoveGlobalUserRoleParams) error
 	RemoveUserFromTeam(ctx context.Context, arg RemoveUserFromTeamParams) error
 	ResetReconcilerConfig(ctx context.Context, reconciler ReconcilerName) error
+	SetLastSuccessfulSyncForTeam(ctx context.Context, slug slug.Slug) error
 	SetReconcilerErrorForTeam(ctx context.Context, arg SetReconcilerErrorForTeamParams) error
 	SetReconcilerStateForTeam(ctx context.Context, arg SetReconcilerStateForTeamParams) error
 	SetSessionExpires(ctx context.Context, arg SetSessionExpiresParams) (*Session, error)

--- a/pkg/sqlc/querier.go
+++ b/pkg/sqlc/querier.go
@@ -44,7 +44,6 @@ type Querier interface {
 	GetServiceAccountRoles(ctx context.Context, serviceAccountID uuid.UUID) ([]*ServiceAccountRole, error)
 	GetServiceAccounts(ctx context.Context) ([]*ServiceAccount, error)
 	GetSessionByID(ctx context.Context, id uuid.UUID) (*Session, error)
-	GetTeamByID(ctx context.Context, id uuid.UUID) (*Team, error)
 	GetTeamBySlug(ctx context.Context, slug slug.Slug) (*Team, error)
 	GetTeamMembers(ctx context.Context, targetTeamSlug *slug.Slug) ([]*User, error)
 	GetTeamMetadata(ctx context.Context, teamSlug slug.Slug) ([]*TeamMetadatum, error)

--- a/pkg/sqlc/reconciler_states.sql.go
+++ b/pkg/sqlc/reconciler_states.sql.go
@@ -8,41 +8,41 @@ package sqlc
 import (
 	"context"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgtype"
+	"github.com/nais/console/pkg/slug"
 )
 
 const getReconcilerStateForTeam = `-- name: GetReconcilerStateForTeam :one
-SELECT reconciler, team_id, state FROM reconciler_states
-WHERE reconciler = $1 AND team_id = $2
+SELECT reconciler, state, team_slug FROM reconciler_states
+WHERE reconciler = $1 AND team_slug = $2
 `
 
 type GetReconcilerStateForTeamParams struct {
 	Reconciler ReconcilerName
-	TeamID     uuid.UUID
+	TeamSlug   slug.Slug
 }
 
 func (q *Queries) GetReconcilerStateForTeam(ctx context.Context, arg GetReconcilerStateForTeamParams) (*ReconcilerState, error) {
-	row := q.db.QueryRow(ctx, getReconcilerStateForTeam, arg.Reconciler, arg.TeamID)
+	row := q.db.QueryRow(ctx, getReconcilerStateForTeam, arg.Reconciler, arg.TeamSlug)
 	var i ReconcilerState
-	err := row.Scan(&i.Reconciler, &i.TeamID, &i.State)
+	err := row.Scan(&i.Reconciler, &i.State, &i.TeamSlug)
 	return &i, err
 }
 
 const setReconcilerStateForTeam = `-- name: SetReconcilerStateForTeam :exec
-INSERT INTO reconciler_states (reconciler, team_id, state)
+INSERT INTO reconciler_states (reconciler, team_slug, state)
 VALUES($1, $2, $3)
-ON CONFLICT (reconciler, team_id) DO
+ON CONFLICT (reconciler, team_slug) DO
     UPDATE SET state = $3
 `
 
 type SetReconcilerStateForTeamParams struct {
 	Reconciler ReconcilerName
-	TeamID     uuid.UUID
+	TeamSlug   slug.Slug
 	State      pgtype.JSONB
 }
 
 func (q *Queries) SetReconcilerStateForTeam(ctx context.Context, arg SetReconcilerStateForTeamParams) error {
-	_, err := q.db.Exec(ctx, setReconcilerStateForTeam, arg.Reconciler, arg.TeamID, arg.State)
+	_, err := q.db.Exec(ctx, setReconcilerStateForTeam, arg.Reconciler, arg.TeamSlug, arg.State)
 	return err
 }

--- a/pkg/sqlc/service_accounts.sql.go
+++ b/pkg/sqlc/service_accounts.sql.go
@@ -60,7 +60,7 @@ func (q *Queries) GetServiceAccountByName(ctx context.Context, name string) (*Se
 }
 
 const getServiceAccountRoles = `-- name: GetServiceAccountRoles :many
-SELECT id, role_name, service_account_id, target_id FROM service_account_roles
+SELECT id, role_name, service_account_id, target_team_slug, target_service_account_id FROM service_account_roles
 WHERE service_account_id = $1
 `
 
@@ -77,7 +77,8 @@ func (q *Queries) GetServiceAccountRoles(ctx context.Context, serviceAccountID u
 			&i.ID,
 			&i.RoleName,
 			&i.ServiceAccountID,
-			&i.TargetID,
+			&i.TargetTeamSlug,
+			&i.TargetServiceAccountID,
 		); err != nil {
 			return nil, err
 		}

--- a/pkg/sqlc/teams.sql.go
+++ b/pkg/sqlc/teams.sql.go
@@ -74,23 +74,6 @@ func (q *Queries) EnableTeam(ctx context.Context, id uuid.UUID) (*Team, error) {
 	return &i, err
 }
 
-const getTeamByID = `-- name: GetTeamByID :one
-SELECT id, slug, purpose, enabled FROM teams
-WHERE id = $1
-`
-
-func (q *Queries) GetTeamByID(ctx context.Context, id uuid.UUID) (*Team, error) {
-	row := q.db.QueryRow(ctx, getTeamByID, id)
-	var i Team
-	err := row.Scan(
-		&i.ID,
-		&i.Slug,
-		&i.Purpose,
-		&i.Enabled,
-	)
-	return &i, err
-}
-
 const getTeamBySlug = `-- name: GetTeamBySlug :one
 SELECT id, slug, purpose, enabled FROM teams
 WHERE slug = $1

--- a/pkg/sqlc/teams.sql.go
+++ b/pkg/sqlc/teams.sql.go
@@ -16,7 +16,7 @@ import (
 const createTeam = `-- name: CreateTeam :one
 INSERT INTO teams (slug, purpose)
 VALUES ($1, $2)
-RETURNING id, slug, purpose, enabled
+RETURNING slug, purpose, enabled
 `
 
 type CreateTeamParams struct {
@@ -27,67 +27,47 @@ type CreateTeamParams struct {
 func (q *Queries) CreateTeam(ctx context.Context, arg CreateTeamParams) (*Team, error) {
 	row := q.db.QueryRow(ctx, createTeam, arg.Slug, arg.Purpose)
 	var i Team
-	err := row.Scan(
-		&i.ID,
-		&i.Slug,
-		&i.Purpose,
-		&i.Enabled,
-	)
+	err := row.Scan(&i.Slug, &i.Purpose, &i.Enabled)
 	return &i, err
 }
 
 const disableTeam = `-- name: DisableTeam :one
 UPDATE teams
 SET enabled = false
-WHERE id = $1
-RETURNING id, slug, purpose, enabled
+WHERE slug = $1
+RETURNING slug, purpose, enabled
 `
 
-func (q *Queries) DisableTeam(ctx context.Context, id uuid.UUID) (*Team, error) {
-	row := q.db.QueryRow(ctx, disableTeam, id)
+func (q *Queries) DisableTeam(ctx context.Context, slug slug.Slug) (*Team, error) {
+	row := q.db.QueryRow(ctx, disableTeam, slug)
 	var i Team
-	err := row.Scan(
-		&i.ID,
-		&i.Slug,
-		&i.Purpose,
-		&i.Enabled,
-	)
+	err := row.Scan(&i.Slug, &i.Purpose, &i.Enabled)
 	return &i, err
 }
 
 const enableTeam = `-- name: EnableTeam :one
 UPDATE teams
 SET enabled = true
-WHERE id = $1
-RETURNING id, slug, purpose, enabled
+WHERE slug = $1
+RETURNING slug, purpose, enabled
 `
 
-func (q *Queries) EnableTeam(ctx context.Context, id uuid.UUID) (*Team, error) {
-	row := q.db.QueryRow(ctx, enableTeam, id)
+func (q *Queries) EnableTeam(ctx context.Context, slug slug.Slug) (*Team, error) {
+	row := q.db.QueryRow(ctx, enableTeam, slug)
 	var i Team
-	err := row.Scan(
-		&i.ID,
-		&i.Slug,
-		&i.Purpose,
-		&i.Enabled,
-	)
+	err := row.Scan(&i.Slug, &i.Purpose, &i.Enabled)
 	return &i, err
 }
 
 const getTeamBySlug = `-- name: GetTeamBySlug :one
-SELECT id, slug, purpose, enabled FROM teams
+SELECT slug, purpose, enabled FROM teams
 WHERE slug = $1
 `
 
 func (q *Queries) GetTeamBySlug(ctx context.Context, slug slug.Slug) (*Team, error) {
 	row := q.db.QueryRow(ctx, getTeamBySlug, slug)
 	var i Team
-	err := row.Scan(
-		&i.ID,
-		&i.Slug,
-		&i.Purpose,
-		&i.Enabled,
-	)
+	err := row.Scan(&i.Slug, &i.Purpose, &i.Enabled)
 	return &i, err
 }
 
@@ -151,7 +131,7 @@ func (q *Queries) GetTeamMetadata(ctx context.Context, teamSlug slug.Slug) ([]*T
 }
 
 const getTeams = `-- name: GetTeams :many
-SELECT id, slug, purpose, enabled FROM teams
+SELECT slug, purpose, enabled FROM teams
 ORDER BY slug ASC
 `
 
@@ -164,12 +144,7 @@ func (q *Queries) GetTeams(ctx context.Context) ([]*Team, error) {
 	var items []*Team
 	for rows.Next() {
 		var i Team
-		if err := rows.Scan(
-			&i.ID,
-			&i.Slug,
-			&i.Purpose,
-			&i.Enabled,
-		); err != nil {
+		if err := rows.Scan(&i.Slug, &i.Purpose, &i.Enabled); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)
@@ -216,23 +191,18 @@ func (q *Queries) SetTeamMetadata(ctx context.Context, arg SetTeamMetadataParams
 const updateTeam = `-- name: UpdateTeam :one
 UPDATE teams
 SET purpose = COALESCE($1, purpose)
-WHERE id = $2
-RETURNING id, slug, purpose, enabled
+WHERE slug = $2
+RETURNING slug, purpose, enabled
 `
 
 type UpdateTeamParams struct {
 	Purpose sql.NullString
-	ID      uuid.UUID
+	Slug    slug.Slug
 }
 
 func (q *Queries) UpdateTeam(ctx context.Context, arg UpdateTeamParams) (*Team, error) {
-	row := q.db.QueryRow(ctx, updateTeam, arg.Purpose, arg.ID)
+	row := q.db.QueryRow(ctx, updateTeam, arg.Purpose, arg.Slug)
 	var i Team
-	err := row.Scan(
-		&i.ID,
-		&i.Slug,
-		&i.Purpose,
-		&i.Enabled,
-	)
+	err := row.Scan(&i.Slug, &i.Purpose, &i.Enabled)
 	return &i, err
 }

--- a/pkg/sqlc/users.sql.go
+++ b/pkg/sqlc/users.sql.go
@@ -97,7 +97,7 @@ func (q *Queries) GetUserByID(ctx context.Context, id uuid.UUID) (*User, error) 
 }
 
 const getUserTeams = `-- name: GetUserTeams :many
-SELECT teams.slug, teams.purpose, teams.enabled FROM user_roles
+SELECT teams.slug, teams.purpose, teams.enabled, teams.last_successful_sync FROM user_roles
 JOIN teams ON teams.slug = user_roles.target_team_slug
 JOIN users ON users.id = user_roles.user_id
 WHERE user_roles.user_id = $1
@@ -113,7 +113,12 @@ func (q *Queries) GetUserTeams(ctx context.Context, userID uuid.UUID) ([]*Team, 
 	var items []*Team
 	for rows.Next() {
 		var i Team
-		if err := rows.Scan(&i.Slug, &i.Purpose, &i.Enabled); err != nil {
+		if err := rows.Scan(
+			&i.Slug,
+			&i.Purpose,
+			&i.Enabled,
+			&i.LastSuccessfulSync,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)

--- a/pkg/sqlc/users.sql.go
+++ b/pkg/sqlc/users.sql.go
@@ -98,7 +98,7 @@ func (q *Queries) GetUserByID(ctx context.Context, id uuid.UUID) (*User, error) 
 
 const getUserTeams = `-- name: GetUserTeams :many
 SELECT teams.id, teams.slug, teams.purpose, teams.enabled FROM user_roles
-JOIN teams ON teams.id = user_roles.target_id
+JOIN teams ON teams.slug = user_roles.target_team_slug
 JOIN users ON users.id = user_roles.user_id
 WHERE user_roles.user_id = $1
 ORDER BY teams.slug ASC

--- a/pkg/sqlc/users.sql.go
+++ b/pkg/sqlc/users.sql.go
@@ -97,7 +97,7 @@ func (q *Queries) GetUserByID(ctx context.Context, id uuid.UUID) (*User, error) 
 }
 
 const getUserTeams = `-- name: GetUserTeams :many
-SELECT teams.id, teams.slug, teams.purpose, teams.enabled FROM user_roles
+SELECT teams.slug, teams.purpose, teams.enabled FROM user_roles
 JOIN teams ON teams.slug = user_roles.target_team_slug
 JOIN users ON users.id = user_roles.user_id
 WHERE user_roles.user_id = $1
@@ -113,12 +113,7 @@ func (q *Queries) GetUserTeams(ctx context.Context, userID uuid.UUID) ([]*Team, 
 	var items []*Team
 	for rows.Next() {
 		var i Team
-		if err := rows.Scan(
-			&i.ID,
-			&i.Slug,
-			&i.Purpose,
-			&i.Enabled,
-		); err != nil {
+		if err := rows.Scan(&i.Slug, &i.Purpose, &i.Enabled); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -14,6 +14,8 @@ sql:
         emit_all_enum_values: true
         emit_enum_valid_method: true
         overrides:
+          - column: reconciler_states.team_slug
+            go_type: github.com/nais/console/pkg/slug.Slug
           - column: teams.slug
             go_type: github.com/nais/console/pkg/slug.Slug
           - column: team_metadata.team_slug

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -18,7 +18,11 @@ sql:
             go_type: github.com/nais/console/pkg/slug.Slug
           - column: reconciler_states.team_slug
             go_type: github.com/nais/console/pkg/slug.Slug
+          - column: service_account_roles.target_team_slug
+            go_type: "*github.com/nais/console/pkg/slug.Slug"
           - column: teams.slug
             go_type: github.com/nais/console/pkg/slug.Slug
           - column: team_metadata.team_slug
             go_type: github.com/nais/console/pkg/slug.Slug
+          - column: user_roles.target_team_slug
+            go_type: "*github.com/nais/console/pkg/slug.Slug"

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -14,6 +14,8 @@ sql:
         emit_all_enum_values: true
         emit_enum_valid_method: true
         overrides:
+          - column: reconciler_errors.team_slug
+            go_type: github.com/nais/console/pkg/slug.Slug
           - column: reconciler_states.team_slug
             go_type: github.com/nais/console/pkg/slug.Slug
           - column: teams.slug

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -16,3 +16,5 @@ sql:
         overrides:
           - column: teams.slug
             go_type: github.com/nais/console/pkg/slug.Slug
+          - column: team_metadata.team_slug
+            go_type: github.com/nais/console/pkg/slug.Slug

--- a/sqlc/queries/reconciler_errors.sql
+++ b/sqlc/queries/reconciler_errors.sql
@@ -1,14 +1,14 @@
 -- name: ClearReconcilerErrorsForTeam :exec
 DELETE FROM reconciler_errors
-WHERE team_id = $1 AND reconciler = $2;
+WHERE team_slug = $1 AND reconciler = $2;
 
 -- name: SetReconcilerErrorForTeam :exec
-INSERT INTO reconciler_errors (correlation_id, team_id, reconciler, error_message)
+INSERT INTO reconciler_errors (correlation_id, team_slug, reconciler, error_message)
 VALUES ($1, $2, $3, $4)
-ON CONFLICT(team_id, reconciler) DO
+ON CONFLICT(team_slug, reconciler) DO
     UPDATE SET correlation_id = $1, created_at = NOW(), error_message = $4;
 
 -- name: GetTeamReconcilerErrors :many
 SELECT * FROM reconciler_errors
-WHERE team_id = $1
+WHERE team_slug = $1
 ORDER BY created_at DESC;

--- a/sqlc/queries/reconciler_states.sql
+++ b/sqlc/queries/reconciler_states.sql
@@ -1,9 +1,9 @@
 -- name: GetReconcilerStateForTeam :one
 SELECT * FROM reconciler_states
-WHERE reconciler = $1 AND team_id = $2;
+WHERE reconciler = $1 AND team_slug = $2;
 
 -- name: SetReconcilerStateForTeam :exec
-INSERT INTO reconciler_states (reconciler, team_id, state)
+INSERT INTO reconciler_states (reconciler, team_slug, state)
 VALUES($1, $2, $3)
-ON CONFLICT (reconciler, team_id) DO
+ON CONFLICT (reconciler, team_slug) DO
     UPDATE SET state = $3;

--- a/sqlc/queries/roles.sql
+++ b/sqlc/queries/roles.sql
@@ -15,21 +15,16 @@ VALUES ($1, $2) ON CONFLICT DO NOTHING;
 INSERT INTO service_account_roles (service_account_id, role_name)
 VALUES ($1, $2) ON CONFLICT DO NOTHING;
 
--- name: RevokeGlobalRoleFromUser :exec
-DELETE FROM user_roles
-WHERE user_id = $1 AND role_name = $2;
-
--- name: AssignTargetedRoleToUser :exec
-INSERT INTO user_roles (user_id, role_name, target_id)
+-- name: AssignTeamRoleToUser :exec
+INSERT INTO user_roles (user_id, role_name, target_team_slug)
 VALUES ($1, $2, $3) ON CONFLICT DO NOTHING;
-
--- name: RevokeTargetedRoleFromUser :exec
-DELETE FROM user_roles
-WHERE user_id = $1 AND target_id = $2 AND role_name = $3;
 
 -- name: RemoveGlobalUserRole :exec
 DELETE FROM user_roles
-WHERE user_id = $1 AND target_id IS NULL AND role_name = $2;
+WHERE user_id = $1
+AND target_team_slug IS NULL
+AND target_service_account_id IS NULL
+AND role_name = $2;
 
 -- name: RemoveAllUserRoles :exec
 DELETE FROM user_roles

--- a/sqlc/queries/teams.sql
+++ b/sqlc/queries/teams.sql
@@ -17,9 +17,9 @@ WHERE slug = $1;
 
 -- name: GetTeamMembers :many
 SELECT users.* FROM user_roles
-JOIN teams ON teams.id = user_roles.target_id
+JOIN teams ON teams.slug = user_roles.target_team_slug
 JOIN users ON users.id = user_roles.user_id
-WHERE user_roles.target_id = sqlc.arg(team_id)::UUID
+WHERE user_roles.target_team_slug = $1
 ORDER BY users.name ASC;
 
 -- name: GetTeamMetadata :many
@@ -50,3 +50,7 @@ UPDATE teams
 SET enabled = true
 WHERE id = $1
 RETURNING *;
+
+-- name: RemoveUserFromTeam :exec
+DELETE FROM user_roles
+WHERE user_id = $1 AND target_team_slug = $2;

--- a/sqlc/queries/teams.sql
+++ b/sqlc/queries/teams.sql
@@ -50,3 +50,7 @@ RETURNING *;
 -- name: RemoveUserFromTeam :exec
 DELETE FROM user_roles
 WHERE user_id = $1 AND target_team_slug = $2;
+
+-- name: SetLastSuccessfulSyncForTeam :exec
+UPDATE teams SET last_successful_sync = NOW()
+WHERE slug = $1;

--- a/sqlc/queries/teams.sql
+++ b/sqlc/queries/teams.sql
@@ -24,13 +24,13 @@ ORDER BY users.name ASC;
 
 -- name: GetTeamMetadata :many
 SELECT * FROM team_metadata
-WHERE team_id = $1
+WHERE team_slug = $1
 ORDER BY key ASC;
 
 -- name: SetTeamMetadata :exec
-INSERT INTO team_metadata (team_id, key, value)
+INSERT INTO team_metadata (team_slug, key, value)
 VALUES ($1, $2, $3)
-ON CONFLICT (team_id, key) DO
+ON CONFLICT (team_slug, key) DO
     UPDATE SET value = $3;
 
 -- name: UpdateTeam :one

--- a/sqlc/queries/teams.sql
+++ b/sqlc/queries/teams.sql
@@ -32,19 +32,19 @@ ON CONFLICT (team_slug, key) DO
 -- name: UpdateTeam :one
 UPDATE teams
 SET purpose = COALESCE(sqlc.narg(purpose), purpose)
-WHERE id = sqlc.arg(id)
+WHERE slug = sqlc.arg(slug)
 RETURNING *;
 
 -- name: DisableTeam :one
 UPDATE teams
 SET enabled = false
-WHERE id = $1
+WHERE slug = $1
 RETURNING *;
 
 -- name: EnableTeam :one
 UPDATE teams
 SET enabled = true
-WHERE id = $1
+WHERE slug = $1
 RETURNING *;
 
 -- name: RemoveUserFromTeam :exec

--- a/sqlc/queries/teams.sql
+++ b/sqlc/queries/teams.sql
@@ -7,10 +7,6 @@ RETURNING *;
 SELECT * FROM teams
 ORDER BY slug ASC;
 
--- name: GetTeamByID :one
-SELECT * FROM teams
-WHERE id = $1;
-
 -- name: GetTeamBySlug :one
 SELECT * FROM teams
 WHERE slug = $1;

--- a/sqlc/queries/users.sql
+++ b/sqlc/queries/users.sql
@@ -21,7 +21,7 @@ WHERE email = LOWER(sqlc.arg(email));
 
 -- name: GetUserTeams :many
 SELECT teams.* FROM user_roles
-JOIN teams ON teams.id = user_roles.target_id
+JOIN teams ON teams.slug = user_roles.target_team_slug
 JOIN users ON users.id = user_roles.user_id
 WHERE user_roles.user_id = $1
 ORDER BY teams.slug ASC;

--- a/sqlc/schemas/0025_team_slug_as_id.down.sql
+++ b/sqlc/schemas/0025_team_slug_as_id.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+/* We will soon squash the migrations, so no point in supporting a down migration for this one */
+
+COMMIT;

--- a/sqlc/schemas/0025_team_slug_as_id.up.sql
+++ b/sqlc/schemas/0025_team_slug_as_id.up.sql
@@ -36,4 +36,22 @@ ALTER TABLE reconciler_states
     DROP COLUMN team_id,
     ADD PRIMARY KEY(reconciler, team_slug);
 
+/* reconciler_errors */
+
+ALTER TABLE reconciler_errors
+    ADD COLUMN team_slug TEXT;
+
+UPDATE reconciler_errors
+SET team_slug = (
+    SELECT slug
+    FROM teams
+    WHERE teams.id = reconciler_errors.team_id
+);
+
+ALTER TABLE reconciler_errors
+    ALTER COLUMN team_slug SET NOT NULL,
+    ADD CONSTRAINT reconciler_errors_team_slug_fkey FOREIGN KEY(team_slug) REFERENCES teams(slug) ON DELETE CASCADE,
+    DROP COLUMN team_id,
+    ADD CONSTRAINT reconciler_errors_team_id_reconciler_key UNIQUE(team_slug, reconciler);
+
 COMMIT;

--- a/sqlc/schemas/0025_team_slug_as_id.up.sql
+++ b/sqlc/schemas/0025_team_slug_as_id.up.sql
@@ -129,7 +129,7 @@ CREATE UNIQUE INDEX unique_service_account_service_account_role_idx ON service_a
 ALTER TABLE teams
     DROP COLUMN id,
     ADD PRIMARY KEY(slug),
-    DROP CONSTRAINT teams_slug_key CASCADE; /* superflous unique constraint */
+    DROP CONSTRAINT teams_slug_key CASCADE; /* superfluous unique constraint */
 
 
 /* add new constraints that will refer to the primary key instead of the old unique constrant */

--- a/sqlc/schemas/0025_team_slug_as_id.up.sql
+++ b/sqlc/schemas/0025_team_slug_as_id.up.sql
@@ -1,5 +1,7 @@
 BEGIN;
 
+/* team_metadata */
+
 ALTER TABLE team_metadata
     ADD COLUMN team_slug TEXT;
 
@@ -15,5 +17,23 @@ ALTER TABLE team_metadata
     ADD CONSTRAINT team_metadata_team_slug_fkey FOREIGN KEY(team_slug) REFERENCES teams(slug) ON DELETE CASCADE,
     DROP COLUMN team_id,
     ADD PRIMARY KEY(team_slug, key);
+
+/* reconciler_states */
+
+ALTER TABLE reconciler_states
+    ADD COLUMN team_slug TEXT;
+
+UPDATE reconciler_states
+SET team_slug = (
+    SELECT slug
+    FROM teams
+    WHERE teams.id = reconciler_states.team_id
+);
+
+ALTER TABLE reconciler_states
+    ALTER COLUMN team_slug SET NOT NULL,
+    ADD CONSTRAINT reconciler_states_team_slug_fkey FOREIGN KEY(team_slug) REFERENCES teams(slug) ON DELETE CASCADE,
+    DROP COLUMN team_id,
+    ADD PRIMARY KEY(reconciler, team_slug);
 
 COMMIT;

--- a/sqlc/schemas/0025_team_slug_as_id.up.sql
+++ b/sqlc/schemas/0025_team_slug_as_id.up.sql
@@ -54,4 +54,38 @@ ALTER TABLE reconciler_errors
     DROP COLUMN team_id,
     ADD CONSTRAINT reconciler_errors_team_id_reconciler_key UNIQUE(team_slug, reconciler);
 
+/* user_roles */
+
+ALTER TABLE user_roles
+    ADD COLUMN target_team_slug TEXT REFERENCES teams(slug) ON DELETE CASCADE,
+    ADD COLUMN target_service_account_id UUID REFERENCES service_accounts(id) ON DELETE CASCADE;
+
+UPDATE user_roles SET target_team_slug = (SELECT slug FROM teams WHERE id = user_roles.target_id) WHERE target_id IS NOT NULL;
+UPDATE user_roles SET target_service_account_id = (SELECT id FROM service_accounts WHERE id = user_roles.target_id) WHERE target_id IS NOT NULL;
+
+ALTER TABLE user_roles
+    DROP COLUMN target_id;
+
+/* service_account_roles */
+
+ALTER TABLE service_account_roles
+    ADD COLUMN target_team_slug TEXT REFERENCES teams(slug) ON DELETE CASCADE,
+    ADD COLUMN target_service_account_id UUID REFERENCES service_accounts(id) ON DELETE CASCADE;
+
+UPDATE service_account_roles SET target_team_slug = (SELECT slug FROM teams WHERE id = service_account_roles.target_id) WHERE target_id IS NOT NULL;
+UPDATE service_account_roles SET target_service_account_id = (SELECT id FROM service_accounts WHERE id = service_account_roles.target_id) WHERE target_id IS NOT NULL;
+
+ALTER TABLE service_account_roles
+    DROP COLUMN target_id;
+
+/* teams */
+/*
+ALTER TABLE teams
+    DROP COLUMN id,
+    ADD PRIMARY KEY(slug);
+
+
+ */
+
+
 COMMIT;

--- a/sqlc/schemas/0025_team_slug_as_id.up.sql
+++ b/sqlc/schemas/0025_team_slug_as_id.up.sql
@@ -60,8 +60,21 @@ ALTER TABLE user_roles
     ADD COLUMN target_team_slug TEXT REFERENCES teams(slug) ON DELETE CASCADE,
     ADD COLUMN target_service_account_id UUID REFERENCES service_accounts(id) ON DELETE CASCADE;
 
-UPDATE user_roles SET target_team_slug = (SELECT slug FROM teams WHERE id = user_roles.target_id) WHERE target_id IS NOT NULL;
-UPDATE user_roles SET target_service_account_id = (SELECT id FROM service_accounts WHERE id = user_roles.target_id) WHERE target_id IS NOT NULL;
+UPDATE user_roles
+SET target_team_slug = (
+    SELECT slug
+    FROM teams
+    WHERE id = user_roles.target_id
+)
+WHERE target_id IS NOT NULL;
+
+UPDATE user_roles
+SET target_service_account_id = (
+    SELECT id
+    FROM service_accounts
+    WHERE id = user_roles.target_id
+)
+WHERE target_id IS NOT NULL;
 
 ALTER TABLE user_roles
     DROP COLUMN target_id;
@@ -72,8 +85,21 @@ ALTER TABLE service_account_roles
     ADD COLUMN target_team_slug TEXT REFERENCES teams(slug) ON DELETE CASCADE,
     ADD COLUMN target_service_account_id UUID REFERENCES service_accounts(id) ON DELETE CASCADE;
 
-UPDATE service_account_roles SET target_team_slug = (SELECT slug FROM teams WHERE id = service_account_roles.target_id) WHERE target_id IS NOT NULL;
-UPDATE service_account_roles SET target_service_account_id = (SELECT id FROM service_accounts WHERE id = service_account_roles.target_id) WHERE target_id IS NOT NULL;
+UPDATE service_account_roles
+SET target_team_slug = (
+    SELECT slug
+    FROM teams
+    WHERE id = service_account_roles.target_id
+)
+WHERE target_id IS NOT NULL;
+
+UPDATE service_account_roles
+SET target_service_account_id = (
+    SELECT id
+    FROM service_accounts
+    WHERE id = service_account_roles.target_id
+)
+WHERE target_id IS NOT NULL;
 
 ALTER TABLE service_account_roles
     DROP COLUMN target_id;
@@ -81,7 +107,26 @@ ALTER TABLE service_account_roles
 /* teams */
 
 ALTER TABLE teams
-    DROP CONSTRAINT teams_pkey,
-    ADD PRIMARY KEY(slug);
+    DROP COLUMN id,
+    ADD PRIMARY KEY(slug),
+    DROP CONSTRAINT teams_slug_key CASCADE; /* superflous unique constraint */
+
+
+/* add new constraints that will refer to the primary key instead of the old unique constrant */
+
+ALTER TABLE team_metadata
+    ADD CONSTRAINT team_metadata_team_slug_fkey FOREIGN KEY(team_slug) REFERENCES teams(slug) ON DELETE CASCADE;
+
+ALTER TABLE reconciler_states
+    ADD CONSTRAINT reconciler_states_team_slug_fkey FOREIGN KEY(team_slug) REFERENCES teams(slug) ON DELETE CASCADE;
+
+ALTER TABLE reconciler_errors
+    ADD CONSTRAINT reconciler_errors_team_slug_fkey FOREIGN KEY(team_slug) REFERENCES teams(slug) ON DELETE CASCADE;
+
+ALTER TABLE service_account_roles
+    ADD CONSTRAINT service_account_roles_target_team_slug_fkey FOREIGN KEY(target_team_slug) REFERENCES teams(slug) ON DELETE CASCADE;
+
+ALTER TABLE user_roles
+    ADD CONSTRAINT user_roles_target_team_slug_fkey FOREIGN KEY(target_team_slug) REFERENCES teams(slug) ON DELETE CASCADE;
 
 COMMIT;

--- a/sqlc/schemas/0025_team_slug_as_id.up.sql
+++ b/sqlc/schemas/0025_team_slug_as_id.up.sql
@@ -1,0 +1,19 @@
+BEGIN;
+
+ALTER TABLE team_metadata
+    ADD COLUMN team_slug TEXT;
+
+UPDATE team_metadata
+SET team_slug = (
+    SELECT slug
+    FROM teams
+    WHERE teams.id = team_metadata.team_id
+);
+
+ALTER TABLE team_metadata
+    ALTER COLUMN team_slug SET NOT NULL,
+    ADD CONSTRAINT team_metadata_team_slug_fkey FOREIGN KEY(team_slug) REFERENCES teams(slug) ON DELETE CASCADE,
+    DROP COLUMN team_id,
+    ADD PRIMARY KEY(team_slug, key);
+
+COMMIT;

--- a/sqlc/schemas/0025_team_slug_as_id.up.sql
+++ b/sqlc/schemas/0025_team_slug_as_id.up.sql
@@ -79,13 +79,9 @@ ALTER TABLE service_account_roles
     DROP COLUMN target_id;
 
 /* teams */
-/*
+
 ALTER TABLE teams
-    DROP COLUMN id,
+    DROP CONSTRAINT teams_pkey,
     ADD PRIMARY KEY(slug);
-
-
- */
-
 
 COMMIT;

--- a/sqlc/schemas/0025_team_slug_as_id.up.sql
+++ b/sqlc/schemas/0025_team_slug_as_id.up.sql
@@ -60,6 +60,11 @@ ALTER TABLE user_roles
     ADD COLUMN target_team_slug TEXT REFERENCES teams(slug) ON DELETE CASCADE,
     ADD COLUMN target_service_account_id UUID REFERENCES service_accounts(id) ON DELETE CASCADE;
 
+
+
+
+
+
 UPDATE user_roles
 SET target_team_slug = (
     SELECT slug
@@ -83,10 +88,10 @@ ALTER TABLE user_roles
 CREATE UNIQUE INDEX unique_global_user_role_idx ON user_roles (user_id, role_name)
     WHERE target_team_slug IS NULL AND target_service_account_id IS NULL;
 
-CREATE UNIQUE INDEX unique_team_user_role_idx ON user_roles (user_id, role_name)
+CREATE UNIQUE INDEX unique_team_user_role_idx ON user_roles (user_id, role_name, target_team_slug)
     WHERE target_team_slug IS NOT NULL;
 
-CREATE UNIQUE INDEX unique_service_account_user_role_idx ON user_roles (user_id, role_name)
+CREATE UNIQUE INDEX unique_service_account_user_role_idx ON user_roles (user_id, role_name, target_service_account_id)
     WHERE target_service_account_id IS NOT NULL;
 
 /* service_account_roles */
@@ -118,10 +123,10 @@ ALTER TABLE service_account_roles
 CREATE UNIQUE INDEX unique_global_service_account_role_idx ON service_account_roles (service_account_id, role_name)
     WHERE target_team_slug IS NULL AND target_service_account_id IS NULL;
 
-CREATE UNIQUE INDEX unique_team_service_account_role_idx ON service_account_roles (service_account_id, role_name)
+CREATE UNIQUE INDEX unique_team_service_account_role_idx ON service_account_roles (service_account_id, role_name, target_team_slug)
     WHERE target_team_slug IS NOT NULL;
 
-CREATE UNIQUE INDEX unique_service_account_service_account_role_idx ON service_account_roles (service_account_id, role_name)
+CREATE UNIQUE INDEX unique_service_account_service_account_role_idx ON service_account_roles (service_account_id, role_name, target_service_account_id)
     WHERE target_service_account_id IS NOT NULL;
 
 /* teams */

--- a/sqlc/schemas/0025_team_slug_as_id.up.sql
+++ b/sqlc/schemas/0025_team_slug_as_id.up.sql
@@ -77,7 +77,17 @@ SET target_service_account_id = (
 WHERE target_id IS NOT NULL;
 
 ALTER TABLE user_roles
-    DROP COLUMN target_id;
+    DROP COLUMN target_id,
+    ADD CONSTRAINT team_or_service_account CHECK (target_team_slug IS NULL OR target_service_account_id IS NULL);
+
+CREATE UNIQUE INDEX unique_global_user_role_idx ON user_roles (user_id, role_name)
+    WHERE target_team_slug IS NULL AND target_service_account_id IS NULL;
+
+CREATE UNIQUE INDEX unique_team_user_role_idx ON user_roles (user_id, role_name)
+    WHERE target_team_slug IS NOT NULL;
+
+CREATE UNIQUE INDEX unique_service_account_user_role_idx ON user_roles (user_id, role_name)
+    WHERE target_service_account_id IS NOT NULL;
 
 /* service_account_roles */
 
@@ -102,7 +112,17 @@ SET target_service_account_id = (
 WHERE target_id IS NOT NULL;
 
 ALTER TABLE service_account_roles
-    DROP COLUMN target_id;
+    DROP COLUMN target_id,
+    ADD CONSTRAINT team_or_service_account CHECK (target_team_slug IS NULL OR target_service_account_id IS NULL);
+
+CREATE UNIQUE INDEX unique_global_service_account_role_idx ON service_account_roles (service_account_id, role_name)
+    WHERE target_team_slug IS NULL AND target_service_account_id IS NULL;
+
+CREATE UNIQUE INDEX unique_team_service_account_role_idx ON service_account_roles (service_account_id, role_name)
+    WHERE target_team_slug IS NOT NULL;
+
+CREATE UNIQUE INDEX unique_service_account_service_account_role_idx ON service_account_roles (service_account_id, role_name)
+    WHERE target_service_account_id IS NOT NULL;
 
 /* teams */
 

--- a/sqlc/schemas/0026_last_successful_team_sync.down.sql
+++ b/sqlc/schemas/0026_last_successful_team_sync.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE teams DROP COLUMN last_successful_sync;
+
+COMMIT;

--- a/sqlc/schemas/0026_last_successful_team_sync.up.sql
+++ b/sqlc/schemas/0026_last_successful_team_sync.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE teams ADD COLUMN last_successful_sync TIMESTAMP;
+
+COMMIT;


### PR DESCRIPTION
Since slug is unique we might as well use it as a primary key for the teams. This will make the GraphQL API easier to work with as well since we can start passing the team slug when referring to a team.