### PR TITLE
Assign/revoke admin roles

### DIFF
--- a/pkg/db/mock_database.go
+++ b/pkg/db/mock_database.go
@@ -940,20 +940,6 @@ func (_m *MockDatabase) RemoveAllServiceAccountRoles(ctx context.Context, servic
 	return r0
 }
 
-// RemoveAllUserRoles provides a mock function with given fields: ctx, userID
-func (_m *MockDatabase) RemoveAllUserRoles(ctx context.Context, userID uuid.UUID) error {
-	ret := _m.Called(ctx, userID)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID) error); ok {
-		r0 = rf(ctx, userID)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // RemoveApiKeysFromServiceAccount provides a mock function with given fields: ctx, serviceAccountID
 func (_m *MockDatabase) RemoveApiKeysFromServiceAccount(ctx context.Context, serviceAccountID uuid.UUID) error {
 	ret := _m.Called(ctx, serviceAccountID)

--- a/pkg/db/mock_database.go
+++ b/pkg/db/mock_database.go
@@ -889,6 +889,29 @@ func (_m *MockDatabase) GetUsers(ctx context.Context) ([]*User, error) {
 	return r0, r1
 }
 
+// GetUsersWithGloballyAssignedRole provides a mock function with given fields: ctx, roleName
+func (_m *MockDatabase) GetUsersWithGloballyAssignedRole(ctx context.Context, roleName sqlc.RoleName) ([]*User, error) {
+	ret := _m.Called(ctx, roleName)
+
+	var r0 []*User
+	if rf, ok := ret.Get(0).(func(context.Context, sqlc.RoleName) []*User); ok {
+		r0 = rf(ctx, roleName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*User)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, sqlc.RoleName) error); ok {
+		r1 = rf(ctx, roleName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // LoadReconcilerStateForTeam provides a mock function with given fields: ctx, reconcilerName, _a2, state
 func (_m *MockDatabase) LoadReconcilerStateForTeam(ctx context.Context, reconcilerName sqlc.ReconcilerName, _a2 slug.Slug, state interface{}) error {
 	ret := _m.Called(ctx, reconcilerName, _a2, state)
@@ -980,6 +1003,20 @@ func (_m *MockDatabase) ResetReconcilerConfig(ctx context.Context, reconcilerNam
 	}
 
 	return r0, r1
+}
+
+// RevokeGlobalUserRole provides a mock function with given fields: ctx, userID, roleName
+func (_m *MockDatabase) RevokeGlobalUserRole(ctx context.Context, userID uuid.UUID, roleName sqlc.RoleName) error {
+	ret := _m.Called(ctx, userID, roleName)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID, sqlc.RoleName) error); ok {
+		r0 = rf(ctx, userID, roleName)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // SetLastSuccessfulSyncForTeam provides a mock function with given fields: ctx, teamSlug

--- a/pkg/db/role.go
+++ b/pkg/db/role.go
@@ -76,6 +76,22 @@ func (d *database) SetTeamMemberRole(ctx context.Context, userID uuid.UUID, team
 	})
 }
 
+func (d *database) RevokeGlobalUserRole(ctx context.Context, userID uuid.UUID, roleName sqlc.RoleName) error {
+	return d.querier.RevokeGlobalUserRole(ctx, sqlc.RevokeGlobalUserRoleParams{
+		RoleName: roleName,
+		UserID:   userID,
+	})
+}
+
+func (d *database) GetUsersWithGloballyAssignedRole(ctx context.Context, roleName sqlc.RoleName) ([]*User, error) {
+	users, err := d.querier.GetUsersWithGloballyAssignedRole(ctx, roleName)
+	if err != nil {
+		return nil, err
+	}
+
+	return wrapUsers(users), nil
+}
+
 func (d *database) roleFromRoleBinding(ctx context.Context, roleName sqlc.RoleName, targetServiceAccountID uuid.NullUUID, targetTeamSlug *slug.Slug) (*Role, error) {
 	authorizations, err := d.querier.GetRoleAuthorizations(ctx, roleName)
 	if err != nil {

--- a/pkg/db/types.go
+++ b/pkg/db/types.go
@@ -148,6 +148,8 @@ type Database interface {
 	DisableTeam(ctx context.Context, teamSlug slug.Slug) (*Team, error)
 	EnableTeam(ctx context.Context, teamSlug slug.Slug) (*Team, error)
 	SetLastSuccessfulSyncForTeam(ctx context.Context, teamSlug slug.Slug) error
+	RevokeGlobalUserRole(ctx context.Context, userID uuid.UUID, roleName sqlc.RoleName) error
+	GetUsersWithGloballyAssignedRole(ctx context.Context, roleName sqlc.RoleName) ([]*User, error)
 }
 
 func (u User) GetID() uuid.UUID {

--- a/pkg/db/types.go
+++ b/pkg/db/types.go
@@ -116,7 +116,6 @@ type Database interface {
 	AssignGlobalRoleToServiceAccount(ctx context.Context, serviceAccountID uuid.UUID, roleName sqlc.RoleName) error
 	RemoveUserFromTeam(ctx context.Context, userID uuid.UUID, teamSlug slug.Slug) error
 	CreateAPIKey(ctx context.Context, apiKey string, serviceAccountID uuid.UUID) error
-	RemoveAllUserRoles(ctx context.Context, userID uuid.UUID) error
 	RemoveAllServiceAccountRoles(ctx context.Context, serviceAccountID uuid.UUID) error
 	RemoveApiKeysFromServiceAccount(ctx context.Context, serviceAccountID uuid.UUID) error
 	GetUserRoles(ctx context.Context, userID uuid.UUID) ([]*Role, error)

--- a/pkg/db/user.go
+++ b/pkg/db/user.go
@@ -17,7 +17,7 @@ func (d *database) CreateUser(ctx context.Context, name, email, externalID strin
 		return nil, err
 	}
 
-	return &User{User: user}, nil
+	return wrapUser(user), nil
 }
 
 func (d *database) DeleteUser(ctx context.Context, userID uuid.UUID) error {
@@ -30,7 +30,7 @@ func (d *database) GetUserByEmail(ctx context.Context, email string) (*User, err
 		return nil, err
 	}
 
-	return &User{User: user}, nil
+	return wrapUser(user), nil
 }
 
 func (d *database) GetUserByID(ctx context.Context, id uuid.UUID) (*User, error) {
@@ -39,7 +39,7 @@ func (d *database) GetUserByID(ctx context.Context, id uuid.UUID) (*User, error)
 		return nil, err
 	}
 
-	return &User{User: user}, nil
+	return wrapUser(user), nil
 }
 
 func (d *database) GetUserByExternalID(ctx context.Context, externalID string) (*User, error) {
@@ -48,7 +48,7 @@ func (d *database) GetUserByExternalID(ctx context.Context, externalID string) (
 		return nil, err
 	}
 
-	return &User{User: user}, nil
+	return wrapUser(user), nil
 }
 
 func (d *database) RemoveAllUserRoles(ctx context.Context, userID uuid.UUID) error {
@@ -66,7 +66,7 @@ func (d *database) UpdateUser(ctx context.Context, userID uuid.UUID, name, email
 		return nil, err
 	}
 
-	return &User{User: user}, nil
+	return wrapUser(user), nil
 }
 
 func (d *database) GetUsers(ctx context.Context) ([]*User, error) {
@@ -75,16 +75,20 @@ func (d *database) GetUsers(ctx context.Context) ([]*User, error) {
 		return nil, err
 	}
 
-	return d.getUsers(users)
+	return wrapUsers(users), nil
 }
 
-func (d *database) getUsers(users []*sqlc.User) ([]*User, error) {
+func wrapUsers(users []*sqlc.User) []*User {
 	result := make([]*User, 0)
 	for _, user := range users {
-		result = append(result, &User{User: user})
+		result = append(result, wrapUser(user))
 	}
 
-	return result, nil
+	return result
+}
+
+func wrapUser(user *sqlc.User) *User {
+	return &User{User: user}
 }
 
 func (d *database) GetUserRoles(ctx context.Context, userID uuid.UUID) ([]*Role, error) {

--- a/pkg/db/user.go
+++ b/pkg/db/user.go
@@ -51,10 +51,6 @@ func (d *database) GetUserByExternalID(ctx context.Context, externalID string) (
 	return wrapUser(user), nil
 }
 
-func (d *database) RemoveAllUserRoles(ctx context.Context, userID uuid.UUID) error {
-	return d.querier.RemoveAllUserRoles(ctx, userID)
-}
-
 func (d *database) UpdateUser(ctx context.Context, userID uuid.UUID, name, email, externalID string) (*User, error) {
 	user, err := d.querier.UpdateUser(ctx, sqlc.UpdateUserParams{
 		Email:      email,

--- a/pkg/sqlc/models.go
+++ b/pkg/sqlc/models.go
@@ -67,6 +67,8 @@ const (
 	AuditActionGraphqlApiReconcilersReset                AuditAction = "graphql-api:reconcilers:reset"
 	AuditActionGraphqlApiTeamDisable                     AuditAction = "graphql-api:team:disable"
 	AuditActionGraphqlApiTeamEnable                      AuditAction = "graphql-api:team:enable"
+	AuditActionUsersyncAssignAdminRole                   AuditAction = "usersync:assign-admin-role"
+	AuditActionUsersyncRevokeAdminRole                   AuditAction = "usersync:revoke-admin-role"
 )
 
 func (e *AuditAction) Scan(src interface{}) error {
@@ -83,7 +85,7 @@ func (e *AuditAction) Scan(src interface{}) error {
 
 type NullAuditAction struct {
 	AuditAction AuditAction
-	Valid       bool // Valid is true if String is not NULL
+	Valid       bool // Valid is true if AuditAction is not NULL
 }
 
 // Scan implements the Scanner interface.
@@ -154,7 +156,9 @@ func (e AuditAction) Valid() bool {
 		AuditActionGraphqlApiReconcilersEnable,
 		AuditActionGraphqlApiReconcilersReset,
 		AuditActionGraphqlApiTeamDisable,
-		AuditActionGraphqlApiTeamEnable:
+		AuditActionGraphqlApiTeamEnable,
+		AuditActionUsersyncAssignAdminRole,
+		AuditActionUsersyncRevokeAdminRole:
 		return true
 	}
 	return false
@@ -211,6 +215,8 @@ func AllAuditActionValues() []AuditAction {
 		AuditActionGraphqlApiReconcilersReset,
 		AuditActionGraphqlApiTeamDisable,
 		AuditActionGraphqlApiTeamEnable,
+		AuditActionUsersyncAssignAdminRole,
+		AuditActionUsersyncRevokeAdminRole,
 	}
 }
 
@@ -237,7 +243,7 @@ func (e *AuditLogsTargetType) Scan(src interface{}) error {
 
 type NullAuditLogsTargetType struct {
 	AuditLogsTargetType AuditLogsTargetType
-	Valid               bool // Valid is true if String is not NULL
+	Valid               bool // Valid is true if AuditLogsTargetType is not NULL
 }
 
 // Scan implements the Scanner interface.
@@ -313,7 +319,7 @@ func (e *AuthzName) Scan(src interface{}) error {
 
 type NullAuthzName struct {
 	AuthzName AuthzName
-	Valid     bool // Valid is true if String is not NULL
+	Valid     bool // Valid is true if AuthzName is not NULL
 }
 
 // Scan implements the Scanner interface.
@@ -404,7 +410,7 @@ func (e *ReconcilerConfigKey) Scan(src interface{}) error {
 
 type NullReconcilerConfigKey struct {
 	ReconcilerConfigKey ReconcilerConfigKey
-	Valid               bool // Valid is true if String is not NULL
+	Valid               bool // Valid is true if ReconcilerConfigKey is not NULL
 }
 
 // Scan implements the Scanner interface.
@@ -475,7 +481,7 @@ func (e *ReconcilerName) Scan(src interface{}) error {
 
 type NullReconcilerName struct {
 	ReconcilerName ReconcilerName
-	Valid          bool // Valid is true if String is not NULL
+	Valid          bool // Valid is true if ReconcilerName is not NULL
 }
 
 // Scan implements the Scanner interface.
@@ -546,7 +552,7 @@ func (e *RoleName) Scan(src interface{}) error {
 
 type NullRoleName struct {
 	RoleName RoleName
-	Valid    bool // Valid is true if String is not NULL
+	Valid    bool // Valid is true if RoleName is not NULL
 }
 
 // Scan implements the Scanner interface.
@@ -625,7 +631,7 @@ func (e *SystemName) Scan(src interface{}) error {
 
 type NullSystemName struct {
 	SystemName SystemName
-	Valid      bool // Valid is true if String is not NULL
+	Valid      bool // Valid is true if SystemName is not NULL
 }
 
 // Scan implements the Scanner interface.

--- a/pkg/sqlc/querier.go
+++ b/pkg/sqlc/querier.go
@@ -57,7 +57,6 @@ type Querier interface {
 	GetUsers(ctx context.Context) ([]*User, error)
 	GetUsersWithGloballyAssignedRole(ctx context.Context, roleName RoleName) ([]*User, error)
 	RemoveAllServiceAccountRoles(ctx context.Context, serviceAccountID uuid.UUID) error
-	RemoveAllUserRoles(ctx context.Context, userID uuid.UUID) error
 	RemoveApiKeysFromServiceAccount(ctx context.Context, serviceAccountID uuid.UUID) error
 	RemoveUserFromTeam(ctx context.Context, arg RemoveUserFromTeamParams) error
 	ResetReconcilerConfig(ctx context.Context, reconciler ReconcilerName) error

--- a/pkg/sqlc/querier.go
+++ b/pkg/sqlc/querier.go
@@ -55,12 +55,13 @@ type Querier interface {
 	GetUserRoles(ctx context.Context, userID uuid.UUID) ([]*UserRole, error)
 	GetUserTeams(ctx context.Context, userID uuid.UUID) ([]*Team, error)
 	GetUsers(ctx context.Context) ([]*User, error)
+	GetUsersWithGloballyAssignedRole(ctx context.Context, roleName RoleName) ([]*User, error)
 	RemoveAllServiceAccountRoles(ctx context.Context, serviceAccountID uuid.UUID) error
 	RemoveAllUserRoles(ctx context.Context, userID uuid.UUID) error
 	RemoveApiKeysFromServiceAccount(ctx context.Context, serviceAccountID uuid.UUID) error
-	RemoveGlobalUserRole(ctx context.Context, arg RemoveGlobalUserRoleParams) error
 	RemoveUserFromTeam(ctx context.Context, arg RemoveUserFromTeamParams) error
 	ResetReconcilerConfig(ctx context.Context, reconciler ReconcilerName) error
+	RevokeGlobalUserRole(ctx context.Context, arg RevokeGlobalUserRoleParams) error
 	SetLastSuccessfulSyncForTeam(ctx context.Context, slug slug.Slug) error
 	SetReconcilerErrorForTeam(ctx context.Context, arg SetReconcilerErrorForTeamParams) error
 	SetReconcilerStateForTeam(ctx context.Context, arg SetReconcilerStateForTeamParams) error

--- a/pkg/sqlc/roles.sql.go
+++ b/pkg/sqlc/roles.sql.go
@@ -158,16 +158,6 @@ func (q *Queries) RemoveAllServiceAccountRoles(ctx context.Context, serviceAccou
 	return err
 }
 
-const removeAllUserRoles = `-- name: RemoveAllUserRoles :exec
-DELETE FROM user_roles
-WHERE user_id = $1
-`
-
-func (q *Queries) RemoveAllUserRoles(ctx context.Context, userID uuid.UUID) error {
-	_, err := q.db.Exec(ctx, removeAllUserRoles, userID)
-	return err
-}
-
 const revokeGlobalUserRole = `-- name: RevokeGlobalUserRole :exec
 DELETE FROM user_roles
 WHERE user_id = $1

--- a/sqlc/queries/roles.sql
+++ b/sqlc/queries/roles.sql
@@ -26,10 +26,6 @@ AND target_team_slug IS NULL
 AND target_service_account_id IS NULL
 AND role_name = $2;
 
--- name: RemoveAllUserRoles :exec
-DELETE FROM user_roles
-WHERE user_id = $1;
-
 -- name: RemoveAllServiceAccountRoles :exec
 DELETE FROM service_account_roles
 WHERE service_account_id = $1;

--- a/sqlc/queries/roles.sql
+++ b/sqlc/queries/roles.sql
@@ -19,7 +19,7 @@ VALUES ($1, $2) ON CONFLICT DO NOTHING;
 INSERT INTO user_roles (user_id, role_name, target_team_slug)
 VALUES ($1, $2, $3) ON CONFLICT DO NOTHING;
 
--- name: RemoveGlobalUserRole :exec
+-- name: RevokeGlobalUserRole :exec
 DELETE FROM user_roles
 WHERE user_id = $1
 AND target_team_slug IS NULL
@@ -33,3 +33,10 @@ WHERE user_id = $1;
 -- name: RemoveAllServiceAccountRoles :exec
 DELETE FROM service_account_roles
 WHERE service_account_id = $1;
+
+-- name: GetUsersWithGloballyAssignedRole :many
+SELECT users.* FROM users
+JOIN user_roles ON user_roles.user_id = users.id
+WHERE user_roles.target_team_slug IS NULL
+AND user_roles.target_service_account_id IS NULL
+AND user_roles.role_name = $1;

--- a/sqlc/schemas/0027_add_audit_action_enum_value.down.sql
+++ b/sqlc/schemas/0027_add_audit_action_enum_value.down.sql
@@ -1,0 +1,1 @@
+/* PostgreSQL does not support removing single items from an ENUM, one must DROP the type, and re-create it */

--- a/sqlc/schemas/0027_add_audit_action_enum_value.up.sql
+++ b/sqlc/schemas/0027_add_audit_action_enum_value.up.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+/* Must use IF NOT EXISTS, since the value can potentially exist */
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'usersync:assign-admin-role';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'usersync:revoke-admin-role';
+
+COMMIT;


### PR DESCRIPTION
Assign / revoke admin roles to users during the user sync, based on members of a specific group in the Google workspace of the tenant.

Resolves #53

