### PR TITLE
Add field for Slack alerts to the team type

### DIFF
--- a/cmd/legacy-migration/main.go
+++ b/cmd/legacy-migration/main.go
@@ -176,11 +176,7 @@ func run(log logger.Logger) error {
 
 			team, err := dbtx.GetTeamBySlug(ctx, convertedTeam.Slug)
 			if err != nil {
-				var slackAlertsChannel *string
-				if convertedTeam.SlackAlertsChannel.Valid {
-					slackAlertsChannel = &convertedTeam.SlackAlertsChannel.String
-				}
-				team, err = dbtx.CreateTeam(ctx, convertedTeam.Slug, convertedTeam.Purpose, slackAlertsChannel)
+				team, err = dbtx.CreateTeam(ctx, convertedTeam.Slug, convertedTeam.Purpose, convertedTeam.SlackAlertsChannel)
 				if err != nil {
 					return err
 				}

--- a/cmd/legacy-migration/main.go
+++ b/cmd/legacy-migration/main.go
@@ -172,16 +172,15 @@ func run(log logger.Logger) error {
 				delete(teamMembers, user.Email)
 			}
 
-			convertedTeam, metadata := yamlteam.Convert()
+			convertedTeam := yamlteam.Convert()
 
 			team, err := dbtx.GetTeamBySlug(ctx, convertedTeam.Slug)
 			if err != nil {
-				team, err = dbtx.CreateTeam(ctx, convertedTeam.Slug, convertedTeam.Purpose)
-				if err != nil {
-					return err
+				var slackAlertsChannel *string
+				if convertedTeam.SlackAlertsChannel.Valid {
+					slackAlertsChannel = &convertedTeam.SlackAlertsChannel.String
 				}
-
-				err = dbtx.SetTeamMetadata(ctx, team.Slug, metadata)
+				team, err = dbtx.CreateTeam(ctx, convertedTeam.Slug, convertedTeam.Purpose, slackAlertsChannel)
 				if err != nil {
 					return err
 				}

--- a/graphql/teams.graphqls
+++ b/graphql/teams.graphqls
@@ -276,7 +276,7 @@ input UpdateTeamInput {
     "Specify team purpose to update the existing value."
     purpose: String
 
-    "Specify the Slack channel where NAIS alerts will be sent."
+    "Specify the Slack channel where NAIS alerts will be sent. Set to an empty string to remove the existing value."
     slackAlertsChannel: String
 }
 

--- a/graphql/teams.graphqls
+++ b/graphql/teams.graphqls
@@ -268,7 +268,7 @@ input CreateTeamInput {
     purpose: String!
 
     "Specify the Slack channel where NAIS alerts will be sent."
-    slackAlertsChannel: String
+    slackAlertsChannel: String!
 }
 
 "Input for updating an existing team."
@@ -276,7 +276,7 @@ input UpdateTeamInput {
     "Specify team purpose to update the existing value."
     purpose: String
 
-    "Specify the Slack channel where NAIS alerts will be sent. Set to an empty string to remove the existing value."
+    "Specify the Slack channel to update the existing value."
     slackAlertsChannel: String
 }
 

--- a/graphql/teams.graphqls
+++ b/graphql/teams.graphqls
@@ -173,6 +173,9 @@ type Team {
 
     "Current reconciler state for the team."
     reconcilerState: ReconcilerState!
+
+    "Slack channel for NAIS alerts."
+    slackAlertsChannel: String
 }
 
 "Reconciler state type."
@@ -263,12 +266,18 @@ input CreateTeamInput {
 
     "Team purpose."
     purpose: String!
+
+    "Specify the Slack channel where NAIS alerts will be sent."
+    slackAlertsChannel: String
 }
 
 "Input for updating an existing team."
 input UpdateTeamInput {
     "Specify team purpose to update the existing value."
     purpose: String
+
+    "Specify the Slack channel where NAIS alerts will be sent."
+    slackAlertsChannel: String
 }
 
 "Available team roles."

--- a/pkg/db/mock_database.go
+++ b/pkg/db/mock_database.go
@@ -157,13 +157,13 @@ func (_m *MockDatabase) CreateSession(ctx context.Context, userID uuid.UUID) (*S
 	return r0, r1
 }
 
-// CreateTeam provides a mock function with given fields: ctx, _a1, purpose
-func (_m *MockDatabase) CreateTeam(ctx context.Context, _a1 slug.Slug, purpose string) (*Team, error) {
-	ret := _m.Called(ctx, _a1, purpose)
+// CreateTeam provides a mock function with given fields: ctx, _a1, purpose, slackAlertsChannel
+func (_m *MockDatabase) CreateTeam(ctx context.Context, _a1 slug.Slug, purpose string, slackAlertsChannel *string) (*Team, error) {
+	ret := _m.Called(ctx, _a1, purpose, slackAlertsChannel)
 
 	var r0 *Team
-	if rf, ok := ret.Get(0).(func(context.Context, slug.Slug, string) *Team); ok {
-		r0 = rf(ctx, _a1, purpose)
+	if rf, ok := ret.Get(0).(func(context.Context, slug.Slug, string, *string) *Team); ok {
+		r0 = rf(ctx, _a1, purpose, slackAlertsChannel)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*Team)
@@ -171,8 +171,8 @@ func (_m *MockDatabase) CreateTeam(ctx context.Context, _a1 slug.Slug, purpose s
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, slug.Slug, string) error); ok {
-		r1 = rf(ctx, _a1, purpose)
+	if rf, ok := ret.Get(1).(func(context.Context, slug.Slug, string, *string) error); ok {
+		r1 = rf(ctx, _a1, purpose, slackAlertsChannel)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1089,13 +1089,13 @@ func (_m *MockDatabase) Transaction(ctx context.Context, fn DatabaseTransactionF
 	return r0
 }
 
-// UpdateTeam provides a mock function with given fields: ctx, teamSlug, purpose
-func (_m *MockDatabase) UpdateTeam(ctx context.Context, teamSlug slug.Slug, purpose *string) (*Team, error) {
-	ret := _m.Called(ctx, teamSlug, purpose)
+// UpdateTeam provides a mock function with given fields: ctx, teamSlug, purpose, slackAlertsChannel
+func (_m *MockDatabase) UpdateTeam(ctx context.Context, teamSlug slug.Slug, purpose *string, slackAlertsChannel *string) (*Team, error) {
+	ret := _m.Called(ctx, teamSlug, purpose, slackAlertsChannel)
 
 	var r0 *Team
-	if rf, ok := ret.Get(0).(func(context.Context, slug.Slug, *string) *Team); ok {
-		r0 = rf(ctx, teamSlug, purpose)
+	if rf, ok := ret.Get(0).(func(context.Context, slug.Slug, *string, *string) *Team); ok {
+		r0 = rf(ctx, teamSlug, purpose, slackAlertsChannel)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*Team)
@@ -1103,8 +1103,8 @@ func (_m *MockDatabase) UpdateTeam(ctx context.Context, teamSlug slug.Slug, purp
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, slug.Slug, *string) error); ok {
-		r1 = rf(ctx, teamSlug, purpose)
+	if rf, ok := ret.Get(1).(func(context.Context, slug.Slug, *string, *string) error); ok {
+		r1 = rf(ctx, teamSlug, purpose, slackAlertsChannel)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/db/mock_database.go
+++ b/pkg/db/mock_database.go
@@ -158,11 +158,11 @@ func (_m *MockDatabase) CreateSession(ctx context.Context, userID uuid.UUID) (*S
 }
 
 // CreateTeam provides a mock function with given fields: ctx, _a1, purpose, slackAlertsChannel
-func (_m *MockDatabase) CreateTeam(ctx context.Context, _a1 slug.Slug, purpose string, slackAlertsChannel *string) (*Team, error) {
+func (_m *MockDatabase) CreateTeam(ctx context.Context, _a1 slug.Slug, purpose string, slackAlertsChannel string) (*Team, error) {
 	ret := _m.Called(ctx, _a1, purpose, slackAlertsChannel)
 
 	var r0 *Team
-	if rf, ok := ret.Get(0).(func(context.Context, slug.Slug, string, *string) *Team); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, slug.Slug, string, string) *Team); ok {
 		r0 = rf(ctx, _a1, purpose, slackAlertsChannel)
 	} else {
 		if ret.Get(0) != nil {
@@ -171,7 +171,7 @@ func (_m *MockDatabase) CreateTeam(ctx context.Context, _a1 slug.Slug, purpose s
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, slug.Slug, string, *string) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, slug.Slug, string, string) error); ok {
 		r1 = rf(ctx, _a1, purpose, slackAlertsChannel)
 	} else {
 		r1 = ret.Error(1)

--- a/pkg/db/team.go
+++ b/pkg/db/team.go
@@ -66,11 +66,11 @@ func (d *database) UpdateTeam(ctx context.Context, teamSlug slug.Slug, purpose, 
 	return &Team{Team: team}, nil
 }
 
-func (d *database) CreateTeam(ctx context.Context, slug slug.Slug, purpose string, slackAlertsChannel *string) (*Team, error) {
+func (d *database) CreateTeam(ctx context.Context, slug slug.Slug, purpose, slackAlertsChannel string) (*Team, error) {
 	team, err := d.querier.CreateTeam(ctx, sqlc.CreateTeamParams{
 		Slug:               slug,
 		Purpose:            purpose,
-		SlackAlertsChannel: nullString(slackAlertsChannel),
+		SlackAlertsChannel: slackAlertsChannel,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/db/team.go
+++ b/pkg/db/team.go
@@ -53,10 +53,11 @@ func (d *database) RemoveUserFromTeam(ctx context.Context, userID uuid.UUID, tea
 	})
 }
 
-func (d *database) UpdateTeam(ctx context.Context, teamSlug slug.Slug, purpose *string) (*Team, error) {
+func (d *database) UpdateTeam(ctx context.Context, teamSlug slug.Slug, purpose, slackAlertsChannel *string) (*Team, error) {
 	team, err := d.querier.UpdateTeam(ctx, sqlc.UpdateTeamParams{
-		Slug:    teamSlug,
-		Purpose: nullString(purpose),
+		Slug:               teamSlug,
+		Purpose:            nullString(purpose),
+		SlackAlertsChannel: nullString(slackAlertsChannel),
 	})
 	if err != nil {
 		return nil, err
@@ -65,10 +66,11 @@ func (d *database) UpdateTeam(ctx context.Context, teamSlug slug.Slug, purpose *
 	return &Team{Team: team}, nil
 }
 
-func (d *database) CreateTeam(ctx context.Context, slug slug.Slug, purpose string) (*Team, error) {
+func (d *database) CreateTeam(ctx context.Context, slug slug.Slug, purpose string, slackAlertsChannel *string) (*Team, error) {
 	team, err := d.querier.CreateTeam(ctx, sqlc.CreateTeamParams{
-		Slug:    slug,
-		Purpose: purpose,
+		Slug:               slug,
+		Purpose:            purpose,
+		SlackAlertsChannel: nullString(slackAlertsChannel),
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/db/types.go
+++ b/pkg/db/types.go
@@ -102,7 +102,7 @@ type Database interface {
 	DeleteUser(ctx context.Context, userID uuid.UUID) error
 	GetUsers(ctx context.Context) ([]*User, error)
 	GetUserTeams(ctx context.Context, userID uuid.UUID) ([]*Team, error)
-	CreateTeam(ctx context.Context, slug slug.Slug, purpose string, slackAlertsChannel *string) (*Team, error)
+	CreateTeam(ctx context.Context, slug slug.Slug, purpose, slackAlertsChannel string) (*Team, error)
 	SetTeamMetadata(ctx context.Context, slug slug.Slug, metadata []TeamMetadata) error
 	GetTeamMetadata(ctx context.Context, slug slug.Slug) ([]*TeamMetadata, error)
 	UpdateTeam(ctx context.Context, teamSlug slug.Slug, purpose, slackAlertsChannel *string) (*Team, error)

--- a/pkg/db/types.go
+++ b/pkg/db/types.go
@@ -102,10 +102,10 @@ type Database interface {
 	DeleteUser(ctx context.Context, userID uuid.UUID) error
 	GetUsers(ctx context.Context) ([]*User, error)
 	GetUserTeams(ctx context.Context, userID uuid.UUID) ([]*Team, error)
-	CreateTeam(ctx context.Context, slug slug.Slug, purpose string) (*Team, error)
+	CreateTeam(ctx context.Context, slug slug.Slug, purpose string, slackAlertsChannel *string) (*Team, error)
 	SetTeamMetadata(ctx context.Context, slug slug.Slug, metadata []TeamMetadata) error
 	GetTeamMetadata(ctx context.Context, slug slug.Slug) ([]*TeamMetadata, error)
-	UpdateTeam(ctx context.Context, teamSlug slug.Slug, purpose *string) (*Team, error)
+	UpdateTeam(ctx context.Context, teamSlug slug.Slug, purpose, slackAlertsChannel *string) (*Team, error)
 	GetTeamBySlug(ctx context.Context, slug slug.Slug) (*Team, error)
 	GetTeams(ctx context.Context) ([]*Team, error)
 	GetTeamMembers(ctx context.Context, teamSlug slug.Slug) ([]*User, error)

--- a/pkg/fixtures/naisteam.go
+++ b/pkg/fixtures/naisteam.go
@@ -16,7 +16,7 @@ func CreateNaisVerification(ctx context.Context, database db.Database) error {
 	_, err := database.GetTeamBySlug(ctx, Slug)
 	if err != nil {
 		if err == pgx.ErrNoRows {
-			_, err = database.CreateTeam(ctx, Slug, Purpose)
+			_, err = database.CreateTeam(ctx, Slug, Purpose, nil)
 		}
 	}
 

--- a/pkg/fixtures/naisteam.go
+++ b/pkg/fixtures/naisteam.go
@@ -8,15 +8,16 @@ import (
 )
 
 const (
-	Slug    = "nais-verification"
-	Purpose = "A place for NAIS to run verification workloads"
+	Slug               = "nais-verification"
+	Purpose            = "A place for NAIS to run verification workloads"
+	SlackAlertsChannel = "#nais-alerts-prod"
 )
 
 func CreateNaisVerification(ctx context.Context, database db.Database) error {
 	_, err := database.GetTeamBySlug(ctx, Slug)
 	if err != nil {
 		if err == pgx.ErrNoRows {
-			_, err = database.CreateTeam(ctx, Slug, Purpose, nil)
+			_, err = database.CreateTeam(ctx, Slug, Purpose, SlackAlertsChannel)
 		}
 	}
 

--- a/pkg/graph/apierror/errors.go
+++ b/pkg/graph/apierror/errors.go
@@ -15,13 +15,14 @@ import (
 )
 
 var (
-	ErrTeamSlug            = Errorf("Your team identifier does not fit our requirements. Team identifiers must contain only lowercase alphanumeric characters or hyphens, contain at least 3 characters and at most 30 characters, start with an alphabetic character, end with an alphanumeric character, and not contain two hyphens in a row.")
-	ErrInternal            = Errorf("The server errored out while processing your request, and we didn't write a suitable error message. You might consider that a bug on our side. Please try again, and if the error persists, contact the NAIS team.")
-	ErrDatabase            = Errorf("The database system encountered an error while processing your request. This is probably a transient error, please try again. If the error persists, contact the NAIS team.")
-	ErrTeamPurpose         = Errorf("You must specify the purpose for your team. This is a human-readable string which is used in external systems, and is important because other people might need to to understand what your team is all about.")
-	ErrTeamNotExist        = Errorf("The team you are referring to does not exist in our database.")
-	ErrTeamPrefixReserved  = Errorf("The name prefix 'nais' is reserved for NAIS systems. You cannot create a team that starts with that string. Choose a different name.")
-	ErrTeamPrefixRedundant = Errorf("The name prefix 'team' is redundant. When you create a team, it is by definition a team. Try again with a different name, perhaps just removing the prefix?")
+	ErrTeamSlug               = Errorf("Your team identifier does not fit our requirements. Team identifiers must contain only lowercase alphanumeric characters or hyphens, contain at least 3 characters and at most 30 characters, start with an alphabetic character, end with an alphanumeric character, and not contain two hyphens in a row.")
+	ErrTeamSlackAlertsChannel = Errorf("The Slack alerts channel does not fit the requirements. The name must contain at least 2 characters and at most 80 characters. The name must consist of lowercase letters, numbers, hyphens and underscores, and it must be prefixed with a hash symbol.")
+	ErrInternal               = Errorf("The server errored out while processing your request, and we didn't write a suitable error message. You might consider that a bug on our side. Please try again, and if the error persists, contact the NAIS team.")
+	ErrDatabase               = Errorf("The database system encountered an error while processing your request. This is probably a transient error, please try again. If the error persists, contact the NAIS team.")
+	ErrTeamPurpose            = Errorf("You must specify the purpose for your team. This is a human-readable string which is used in external systems, and is important because other people might need to to understand what your team is all about.")
+	ErrTeamNotExist           = Errorf("The team you are referring to does not exist in our database.")
+	ErrTeamPrefixReserved     = Errorf("The name prefix 'nais' is reserved for NAIS systems. You cannot create a team that starts with that string. Choose a different name.")
+	ErrTeamPrefixRedundant    = Errorf("The name prefix 'team' is redundant. When you create a team, it is by definition a team. Try again with a different name, perhaps just removing the prefix?")
 )
 
 type Error struct {

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -259,7 +259,6 @@ type TeamResolver interface {
 
 	LastSuccessfulSync(ctx context.Context, obj *db.Team) (*time.Time, error)
 	ReconcilerState(ctx context.Context, obj *db.Team) (*model.ReconcilerState, error)
-	SlackAlertsChannel(ctx context.Context, obj *db.Team) (*string, error)
 }
 type UserResolver interface {
 	Teams(ctx context.Context, obj *db.User) ([]*model.TeamMembership, error)
@@ -1645,7 +1644,7 @@ input CreateTeamInput {
     purpose: String!
 
     "Specify the Slack channel where NAIS alerts will be sent."
-    slackAlertsChannel: String
+    slackAlertsChannel: String!
 }
 
 "Input for updating an existing team."
@@ -1653,7 +1652,7 @@ input UpdateTeamInput {
     "Specify team purpose to update the existing value."
     purpose: String
 
-    "Specify the Slack channel where NAIS alerts will be sent. Set to an empty string to remove the existing value."
+    "Specify the Slack channel to update the existing value."
     slackAlertsChannel: String
 }
 
@@ -7097,7 +7096,7 @@ func (ec *executionContext) _Team_slackAlertsChannel(ctx context.Context, field 
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Team().SlackAlertsChannel(rctx, obj)
+		return obj.SlackAlertsChannel, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -7106,17 +7105,17 @@ func (ec *executionContext) _Team_slackAlertsChannel(ctx context.Context, field 
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalOString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Team_slackAlertsChannel(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Team",
 		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
+		IsMethod:   false,
+		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
 		},
@@ -9572,7 +9571,7 @@ func (ec *executionContext) unmarshalInputCreateTeamInput(ctx context.Context, o
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("slackAlertsChannel"))
-			it.SlackAlertsChannel, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			it.SlackAlertsChannel, err = ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -10816,22 +10815,9 @@ func (ec *executionContext) _Team(ctx context.Context, sel ast.SelectionSet, obj
 
 			})
 		case "slackAlertsChannel":
-			field := field
 
-			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Team_slackAlertsChannel(ctx, field, obj)
-				return res
-			}
+			out.Values[i] = ec._Team_slackAlertsChannel(ctx, field, obj)
 
-			out.Concurrently(i, func() graphql.Marshaler {
-				return innerFunc(ctx)
-
-			})
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -12704,6 +12690,16 @@ func (ec *executionContext) marshalOSlug2ᚖgithubᚗcomᚋnaisᚋconsoleᚋpkg�
 		return graphql.Null
 	}
 	res := slug.MarshalSlug(v)
+	return res
+}
+
+func (ec *executionContext) unmarshalOString2string(ctx context.Context, v interface{}) (string, error) {
+	res, err := graphql.UnmarshalString(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOString2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	res := graphql.MarshalString(v)
 	return res
 }
 

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -169,6 +169,7 @@ type ComplexityRoot struct {
 		Metadata           func(childComplexity int) int
 		Purpose            func(childComplexity int) int
 		ReconcilerState    func(childComplexity int) int
+		SlackAlertsChannel func(childComplexity int) int
 		Slug               func(childComplexity int) int
 		SyncErrors         func(childComplexity int) int
 	}
@@ -258,6 +259,7 @@ type TeamResolver interface {
 
 	LastSuccessfulSync(ctx context.Context, obj *db.Team) (*time.Time, error)
 	ReconcilerState(ctx context.Context, obj *db.Team) (*model.ReconcilerState, error)
+	SlackAlertsChannel(ctx context.Context, obj *db.Team) (*string, error)
 }
 type UserResolver interface {
 	Teams(ctx context.Context, obj *db.User) ([]*model.TeamMembership, error)
@@ -923,6 +925,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Team.ReconcilerState(childComplexity), true
 
+	case "Team.slackAlertsChannel":
+		if e.complexity.Team.SlackAlertsChannel == nil {
+			break
+		}
+
+		return e.complexity.Team.SlackAlertsChannel(childComplexity), true
+
 	case "Team.slug":
 		if e.complexity.Team.Slug == nil {
 			break
@@ -1541,6 +1550,9 @@ type Team {
 
     "Current reconciler state for the team."
     reconcilerState: ReconcilerState!
+
+    "Slack channel for NAIS alerts."
+    slackAlertsChannel: String
 }
 
 "Reconciler state type."
@@ -1631,12 +1643,18 @@ input CreateTeamInput {
 
     "Team purpose."
     purpose: String!
+
+    "Specify the Slack channel where NAIS alerts will be sent."
+    slackAlertsChannel: String
 }
 
 "Input for updating an existing team."
 input UpdateTeamInput {
     "Specify team purpose to update the existing value."
     purpose: String
+
+    "Specify the Slack channel where NAIS alerts will be sent."
+    slackAlertsChannel: String
 }
 
 "Available team roles."
@@ -2784,6 +2802,8 @@ func (ec *executionContext) fieldContext_Mutation_setGitHubTeamSlug(ctx context.
 				return ec.fieldContext_Team_lastSuccessfulSync(ctx, field)
 			case "reconcilerState":
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
+			case "slackAlertsChannel":
+				return ec.fieldContext_Team_slackAlertsChannel(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -2879,6 +2899,8 @@ func (ec *executionContext) fieldContext_Mutation_setGoogleWorkspaceGroupEmail(c
 				return ec.fieldContext_Team_lastSuccessfulSync(ctx, field)
 			case "reconcilerState":
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
+			case "slackAlertsChannel":
+				return ec.fieldContext_Team_slackAlertsChannel(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -2974,6 +2996,8 @@ func (ec *executionContext) fieldContext_Mutation_setAzureADGroupId(ctx context.
 				return ec.fieldContext_Team_lastSuccessfulSync(ctx, field)
 			case "reconcilerState":
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
+			case "slackAlertsChannel":
+				return ec.fieldContext_Team_slackAlertsChannel(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -3069,6 +3093,8 @@ func (ec *executionContext) fieldContext_Mutation_setGcpProjectId(ctx context.Co
 				return ec.fieldContext_Team_lastSuccessfulSync(ctx, field)
 			case "reconcilerState":
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
+			case "slackAlertsChannel":
+				return ec.fieldContext_Team_slackAlertsChannel(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -3164,6 +3190,8 @@ func (ec *executionContext) fieldContext_Mutation_setNaisNamespace(ctx context.C
 				return ec.fieldContext_Team_lastSuccessfulSync(ctx, field)
 			case "reconcilerState":
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
+			case "slackAlertsChannel":
+				return ec.fieldContext_Team_slackAlertsChannel(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -3631,6 +3659,8 @@ func (ec *executionContext) fieldContext_Mutation_createTeam(ctx context.Context
 				return ec.fieldContext_Team_lastSuccessfulSync(ctx, field)
 			case "reconcilerState":
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
+			case "slackAlertsChannel":
+				return ec.fieldContext_Team_slackAlertsChannel(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -3726,6 +3756,8 @@ func (ec *executionContext) fieldContext_Mutation_updateTeam(ctx context.Context
 				return ec.fieldContext_Team_lastSuccessfulSync(ctx, field)
 			case "reconcilerState":
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
+			case "slackAlertsChannel":
+				return ec.fieldContext_Team_slackAlertsChannel(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -3821,6 +3853,8 @@ func (ec *executionContext) fieldContext_Mutation_removeUsersFromTeam(ctx contex
 				return ec.fieldContext_Team_lastSuccessfulSync(ctx, field)
 			case "reconcilerState":
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
+			case "slackAlertsChannel":
+				return ec.fieldContext_Team_slackAlertsChannel(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -3997,6 +4031,8 @@ func (ec *executionContext) fieldContext_Mutation_addTeamMembers(ctx context.Con
 				return ec.fieldContext_Team_lastSuccessfulSync(ctx, field)
 			case "reconcilerState":
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
+			case "slackAlertsChannel":
+				return ec.fieldContext_Team_slackAlertsChannel(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -4092,6 +4128,8 @@ func (ec *executionContext) fieldContext_Mutation_addTeamOwners(ctx context.Cont
 				return ec.fieldContext_Team_lastSuccessfulSync(ctx, field)
 			case "reconcilerState":
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
+			case "slackAlertsChannel":
+				return ec.fieldContext_Team_slackAlertsChannel(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -4187,6 +4225,8 @@ func (ec *executionContext) fieldContext_Mutation_setTeamMemberRole(ctx context.
 				return ec.fieldContext_Team_lastSuccessfulSync(ctx, field)
 			case "reconcilerState":
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
+			case "slackAlertsChannel":
+				return ec.fieldContext_Team_slackAlertsChannel(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -4282,6 +4322,8 @@ func (ec *executionContext) fieldContext_Mutation_disableTeam(ctx context.Contex
 				return ec.fieldContext_Team_lastSuccessfulSync(ctx, field)
 			case "reconcilerState":
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
+			case "slackAlertsChannel":
+				return ec.fieldContext_Team_slackAlertsChannel(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -4377,6 +4419,8 @@ func (ec *executionContext) fieldContext_Mutation_enableTeam(ctx context.Context
 				return ec.fieldContext_Team_lastSuccessfulSync(ctx, field)
 			case "reconcilerState":
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
+			case "slackAlertsChannel":
+				return ec.fieldContext_Team_slackAlertsChannel(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -4750,6 +4794,8 @@ func (ec *executionContext) fieldContext_Query_teams(ctx context.Context, field 
 				return ec.fieldContext_Team_lastSuccessfulSync(ctx, field)
 			case "reconcilerState":
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
+			case "slackAlertsChannel":
+				return ec.fieldContext_Team_slackAlertsChannel(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -4834,6 +4880,8 @@ func (ec *executionContext) fieldContext_Query_team(ctx context.Context, field g
 				return ec.fieldContext_Team_lastSuccessfulSync(ctx, field)
 			case "reconcilerState":
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
+			case "slackAlertsChannel":
+				return ec.fieldContext_Team_slackAlertsChannel(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -7035,6 +7083,47 @@ func (ec *executionContext) fieldContext_Team_reconcilerState(ctx context.Contex
 	return fc, nil
 }
 
+func (ec *executionContext) _Team_slackAlertsChannel(ctx context.Context, field graphql.CollectedField, obj *db.Team) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Team_slackAlertsChannel(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Team().SlackAlertsChannel(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Team_slackAlertsChannel(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Team",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _TeamMember_user(ctx context.Context, field graphql.CollectedField, obj *model.TeamMember) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_TeamMember_user(ctx, field)
 	if err != nil {
@@ -7192,6 +7281,8 @@ func (ec *executionContext) fieldContext_TeamMembership_team(ctx context.Context
 				return ec.fieldContext_Team_lastSuccessfulSync(ctx, field)
 			case "reconcilerState":
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
+			case "slackAlertsChannel":
+				return ec.fieldContext_Team_slackAlertsChannel(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -7385,6 +7476,8 @@ func (ec *executionContext) fieldContext_TeamSync_team(ctx context.Context, fiel
 				return ec.fieldContext_Team_lastSuccessfulSync(ctx, field)
 			case "reconcilerState":
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
+			case "slackAlertsChannel":
+				return ec.fieldContext_Team_slackAlertsChannel(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -9452,7 +9545,7 @@ func (ec *executionContext) unmarshalInputCreateTeamInput(ctx context.Context, o
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"slug", "purpose"}
+	fieldsInOrder := [...]string{"slug", "purpose", "slackAlertsChannel"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -9472,6 +9565,14 @@ func (ec *executionContext) unmarshalInputCreateTeamInput(ctx context.Context, o
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("purpose"))
 			it.Purpose, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "slackAlertsChannel":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("slackAlertsChannel"))
+			it.SlackAlertsChannel, err = ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -9524,7 +9625,7 @@ func (ec *executionContext) unmarshalInputUpdateTeamInput(ctx context.Context, o
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"purpose"}
+	fieldsInOrder := [...]string{"purpose", "slackAlertsChannel"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -9536,6 +9637,14 @@ func (ec *executionContext) unmarshalInputUpdateTeamInput(ctx context.Context, o
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("purpose"))
 			it.Purpose, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "slackAlertsChannel":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("slackAlertsChannel"))
+			it.SlackAlertsChannel, err = ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -10699,6 +10808,23 @@ func (ec *executionContext) _Team(ctx context.Context, sel ast.SelectionSet, obj
 				if res == graphql.Null {
 					atomic.AddUint32(&invalids, 1)
 				}
+				return res
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return innerFunc(ctx)
+
+			})
+		case "slackAlertsChannel":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Team_slackAlertsChannel(ctx, field, obj)
 				return res
 			}
 

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -1653,7 +1653,7 @@ input UpdateTeamInput {
     "Specify team purpose to update the existing value."
     purpose: String
 
-    "Specify the Slack channel where NAIS alerts will be sent."
+    "Specify the Slack channel where NAIS alerts will be sent. Set to an empty string to remove the existing value."
     slackAlertsChannel: String
 }
 

--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -21,7 +21,7 @@ type CreateTeamInput struct {
 	// Team purpose.
 	Purpose string `json:"purpose"`
 	// Specify the Slack channel where NAIS alerts will be sent.
-	SlackAlertsChannel *string `json:"slackAlertsChannel"`
+	SlackAlertsChannel string `json:"slackAlertsChannel"`
 }
 
 // GCP project type.
@@ -104,7 +104,7 @@ type TeamSync struct {
 type UpdateTeamInput struct {
 	// Specify team purpose to update the existing value.
 	Purpose *string `json:"purpose"`
-	// Specify the Slack channel where NAIS alerts will be sent. Set to an empty string to remove the existing value.
+	// Specify the Slack channel to update the existing value.
 	SlackAlertsChannel *string `json:"slackAlertsChannel"`
 }
 

--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -104,7 +104,7 @@ type TeamSync struct {
 type UpdateTeamInput struct {
 	// Specify team purpose to update the existing value.
 	Purpose *string `json:"purpose"`
-	// Specify the Slack channel where NAIS alerts will be sent.
+	// Specify the Slack channel where NAIS alerts will be sent. Set to an empty string to remove the existing value.
 	SlackAlertsChannel *string `json:"slackAlertsChannel"`
 }
 

--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -20,6 +20,8 @@ type CreateTeamInput struct {
 	Slug *slug.Slug `json:"slug"`
 	// Team purpose.
 	Purpose string `json:"purpose"`
+	// Specify the Slack channel where NAIS alerts will be sent.
+	SlackAlertsChannel *string `json:"slackAlertsChannel"`
 }
 
 // GCP project type.
@@ -102,6 +104,8 @@ type TeamSync struct {
 type UpdateTeamInput struct {
 	// Specify team purpose to update the existing value.
 	Purpose *string `json:"purpose"`
+	// Specify the Slack channel where NAIS alerts will be sent.
+	SlackAlertsChannel *string `json:"slackAlertsChannel"`
 }
 
 // Available team roles.

--- a/pkg/graph/model/sanitize.go
+++ b/pkg/graph/model/sanitize.go
@@ -6,14 +6,7 @@ import (
 
 func (input CreateTeamInput) Sanitize() CreateTeamInput {
 	input.Purpose = strings.TrimSpace(input.Purpose)
-
-	if input.SlackAlertsChannel != nil && *input.SlackAlertsChannel == "" {
-		input.SlackAlertsChannel = nil
-	}
-
-	if input.SlackAlertsChannel != nil {
-		input.SlackAlertsChannel = ptr(strings.TrimSpace(*input.SlackAlertsChannel))
-	}
+	input.SlackAlertsChannel = strings.TrimSpace(input.SlackAlertsChannel)
 	return input
 }
 

--- a/pkg/graph/model/sanitize.go
+++ b/pkg/graph/model/sanitize.go
@@ -6,6 +6,14 @@ import (
 
 func (input CreateTeamInput) Sanitize() CreateTeamInput {
 	input.Purpose = strings.TrimSpace(input.Purpose)
+
+	if input.SlackAlertsChannel != nil && *input.SlackAlertsChannel == "" {
+		input.SlackAlertsChannel = nil
+	}
+
+	if input.SlackAlertsChannel != nil {
+		input.SlackAlertsChannel = ptr(strings.TrimSpace(*input.SlackAlertsChannel))
+	}
 	return input
 }
 
@@ -13,5 +21,10 @@ func (input UpdateTeamInput) Sanitize() UpdateTeamInput {
 	if input.Purpose != nil {
 		input.Purpose = ptr(strings.TrimSpace(*input.Purpose))
 	}
+
+	if input.SlackAlertsChannel != nil {
+		input.SlackAlertsChannel = ptr(strings.TrimSpace(*input.SlackAlertsChannel))
+	}
+
 	return input
 }

--- a/pkg/graph/model/validate.go
+++ b/pkg/graph/model/validate.go
@@ -38,7 +38,7 @@ func (input CreateTeamInput) Validate() error {
 		return apierror.ErrTeamPrefixRedundant
 	}
 
-	if input.SlackAlertsChannel != nil && !slackChannelNameRegex.MatchString(*input.SlackAlertsChannel) {
+	if !slackChannelNameRegex.MatchString(input.SlackAlertsChannel) {
 		return apierror.ErrTeamSlackAlertsChannel
 	}
 
@@ -50,7 +50,7 @@ func (input UpdateTeamInput) Validate() error {
 		return apierror.ErrTeamPurpose
 	}
 
-	if input.SlackAlertsChannel != nil && *input.SlackAlertsChannel != "" && !slackChannelNameRegex.MatchString(*input.SlackAlertsChannel) {
+	if input.SlackAlertsChannel != nil && !slackChannelNameRegex.MatchString(*input.SlackAlertsChannel) {
 		return apierror.ErrTeamSlackAlertsChannel
 	}
 

--- a/pkg/graph/model/validate.go
+++ b/pkg/graph/model/validate.go
@@ -7,8 +7,13 @@ import (
 	"github.com/nais/console/pkg/graph/apierror"
 )
 
-// Slightly modified from database schema because Golang doesn't like Perl-flavored regexes.
-var teamSlugRegex = regexp.MustCompile("^[a-z](-?[a-z0-9]+)+$")
+var (
+	// Slightly modified from database schema because Golang doesn't like Perl-flavored regexes.
+	teamSlugRegex = regexp.MustCompile("^[a-z](-?[a-z0-9]+)+$")
+
+	// Rules can be found here: https://api.slack.com/methods/conversations.create#naming
+	slackChannelNameRegex = regexp.MustCompile("^#[a-z0-9æøå_-]{2,80}$")
+)
 
 func ptr[T any](value T) *T {
 	return &value
@@ -33,12 +38,20 @@ func (input CreateTeamInput) Validate() error {
 		return apierror.ErrTeamPrefixRedundant
 	}
 
+	if input.SlackAlertsChannel != nil && !slackChannelNameRegex.MatchString(*input.SlackAlertsChannel) {
+		return apierror.ErrTeamSlackAlertsChannel
+	}
+
 	return nil
 }
 
 func (input UpdateTeamInput) Validate() error {
 	if input.Purpose != nil && *input.Purpose == "" {
 		return apierror.ErrTeamPurpose
+	}
+
+	if input.SlackAlertsChannel != nil && *input.SlackAlertsChannel != "" && !slackChannelNameRegex.MatchString(*input.SlackAlertsChannel) {
+		return apierror.ErrTeamSlackAlertsChannel
 	}
 
 	return nil

--- a/pkg/graph/model/validate_test.go
+++ b/pkg/graph/model/validate_test.go
@@ -34,20 +34,21 @@ func TestCreateTeamInput_Validate_SlackAlertsChannel(t *testing.T) {
 	}
 
 	for _, s := range validChannels {
-		tpl.SlackAlertsChannel = ptr(s)
-		assert.NoError(t, tpl.Validate(), "Slack alerts channel %q should pass validation, but didn't", *tpl.SlackAlertsChannel)
+		tpl.SlackAlertsChannel = s
+		assert.NoError(t, tpl.Validate(), "Slack alerts channel %q should pass validation, but didn't", tpl.SlackAlertsChannel)
 	}
 
 	for _, s := range invalidChannels {
-		tpl.SlackAlertsChannel = ptr(s)
-		assert.Error(t, tpl.Validate(), "Slack alerts channel %q passed validation even if it should not", *tpl.SlackAlertsChannel)
+		tpl.SlackAlertsChannel = s
+		assert.Error(t, tpl.Validate(), "Slack alerts channel %q passed validation even if it should not", tpl.SlackAlertsChannel)
 	}
 }
 
 func TestCreateTeamInput_Validate_Slug(t *testing.T) {
 	tpl := model.CreateTeamInput{
-		Slug:    nil,
-		Purpose: "valid purpose",
+		Slug:               nil,
+		Purpose:            "valid purpose",
+		SlackAlertsChannel: "#channel",
 	}
 
 	validSlugs := []string{

--- a/pkg/graph/model/validate_test.go
+++ b/pkg/graph/model/validate_test.go
@@ -12,6 +12,38 @@ func ptr[T any](value T) *T {
 	return &value
 }
 
+func TestCreateTeamInput_Validate_SlackAlertsChannel(t *testing.T) {
+	tpl := model.CreateTeamInput{
+		Slug:    ptr(slug.Slug("valid-slug")),
+		Purpose: "valid purpose",
+	}
+
+	validChannels := []string{
+		"#foo",
+		"#foo-bar",
+		"#æøå",
+		"#aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+	}
+
+	invalidChannels := []string{
+		"foo", // missing hash
+		"#a",  // too short
+		"#aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", // too long
+		"#foo bar", // space not allowed
+		"#Foobar",  // upper case not allowed
+	}
+
+	for _, s := range validChannels {
+		tpl.SlackAlertsChannel = ptr(s)
+		assert.NoError(t, tpl.Validate(), "Slack alerts channel %q should pass validation, but didn't", *tpl.SlackAlertsChannel)
+	}
+
+	for _, s := range invalidChannels {
+		tpl.SlackAlertsChannel = ptr(s)
+		assert.Error(t, tpl.Validate(), "Slack alerts channel %q passed validation even if it should not", *tpl.SlackAlertsChannel)
+	}
+}
+
 func TestCreateTeamInput_Validate_Slug(t *testing.T) {
 	tpl := model.CreateTeamInput{
 		Slug:    nil,
@@ -48,11 +80,11 @@ func TestCreateTeamInput_Validate_Slug(t *testing.T) {
 
 	for _, s := range validSlugs {
 		tpl.Slug = ptr(slug.Slug(s))
-		assert.NoError(t, tpl.Validate(), "Slug '%s' should pass validation, but didn't", tpl.Slug)
+		assert.NoError(t, tpl.Validate(), "Slug %q should pass validation, but didn't", tpl.Slug)
 	}
 
 	for _, s := range invalidSlugs {
 		tpl.Slug = ptr(slug.Slug(s))
-		assert.Error(t, tpl.Validate(), "Slug '%s' passed validation even if it should not", tpl.Slug)
+		assert.Error(t, tpl.Validate(), "Slug %q passed validation even if it should not", tpl.Slug)
 	}
 }

--- a/pkg/graph/teams.go
+++ b/pkg/graph/teams.go
@@ -43,7 +43,7 @@ func (r *mutationResolver) CreateTeam(ctx context.Context, input model.CreateTea
 
 	var team *db.Team
 	err = r.database.Transaction(ctx, func(ctx context.Context, dbtx db.Database) error {
-		team, err = dbtx.CreateTeam(ctx, *input.Slug, input.Purpose)
+		team, err = dbtx.CreateTeam(ctx, *input.Slug, input.Purpose, input.SlackAlertsChannel)
 		if err != nil {
 			return err
 		}
@@ -102,7 +102,7 @@ func (r *mutationResolver) UpdateTeam(ctx context.Context, slug *slug.Slug, inpu
 		return nil, fmt.Errorf("create log correlation ID: %w", err)
 	}
 
-	team, err = r.database.UpdateTeam(ctx, team.Slug, input.Purpose)
+	team, err = r.database.UpdateTeam(ctx, team.Slug, input.Purpose, input.SlackAlertsChannel)
 	if err != nil {
 		return nil, err
 	}
@@ -677,7 +677,10 @@ func (r *teamResolver) ReconcilerState(ctx context.Context, obj *db.Team) (*mode
 
 // SlackAlertsChannel is the resolver for the slackAlertsChannel field.
 func (r *teamResolver) SlackAlertsChannel(ctx context.Context, obj *db.Team) (*string, error) {
-	panic(fmt.Errorf("not implemented: SlackAlertsChannel - slackAlertsChannel"))
+	if !obj.SlackAlertsChannel.Valid || obj.SlackAlertsChannel.String == "" {
+		return nil, nil
+	}
+	return &obj.SlackAlertsChannel.String, nil
 }
 
 // Team returns generated.TeamResolver implementation.

--- a/pkg/graph/teams.go
+++ b/pkg/graph/teams.go
@@ -675,14 +675,6 @@ func (r *teamResolver) ReconcilerState(ctx context.Context, obj *db.Team) (*mode
 	}, nil
 }
 
-// SlackAlertsChannel is the resolver for the slackAlertsChannel field.
-func (r *teamResolver) SlackAlertsChannel(ctx context.Context, obj *db.Team) (*string, error) {
-	if !obj.SlackAlertsChannel.Valid || obj.SlackAlertsChannel.String == "" {
-		return nil, nil
-	}
-	return &obj.SlackAlertsChannel.String, nil
-}
-
 // Team returns generated.TeamResolver implementation.
 func (r *Resolver) Team() generated.TeamResolver { return &teamResolver{r} }
 

--- a/pkg/graph/teams.go
+++ b/pkg/graph/teams.go
@@ -675,6 +675,11 @@ func (r *teamResolver) ReconcilerState(ctx context.Context, obj *db.Team) (*mode
 	}, nil
 }
 
+// SlackAlertsChannel is the resolver for the slackAlertsChannel field.
+func (r *teamResolver) SlackAlertsChannel(ctx context.Context, obj *db.Team) (*string, error) {
+	panic(fmt.Errorf("not implemented: SlackAlertsChannel - slackAlertsChannel"))
+}
+
 // Team returns generated.TeamResolver implementation.
 func (r *Resolver) Team() generated.TeamResolver { return &teamResolver{r} }
 

--- a/pkg/graph/teams_test.go
+++ b/pkg/graph/teams_test.go
@@ -66,7 +66,7 @@ func TestMutationResolver_CreateTeam(t *testing.T) {
 		_, err := resolver.CreateTeam(ctx, model.CreateTeamInput{
 			Slug:               &teamSlug,
 			Purpose:            "  ",
-			SlackAlertsChannel: nil,
+			SlackAlertsChannel: slackChannel,
 		})
 		assert.ErrorContains(t, err, "You must specify the purpose for your team")
 	})
@@ -79,7 +79,7 @@ func TestMutationResolver_CreateTeam(t *testing.T) {
 		dbtx := db.NewMockDatabase(t)
 
 		dbtx.
-			On("CreateTeam", txCtx, teamSlug, "some purpose", &slackChannel).
+			On("CreateTeam", txCtx, teamSlug, "some purpose", slackChannel).
 			Return(createdTeam, nil).
 			Once()
 		dbtx.
@@ -112,7 +112,7 @@ func TestMutationResolver_CreateTeam(t *testing.T) {
 		returnedTeam, err := resolver.CreateTeam(ctx, model.CreateTeamInput{
 			Slug:               &teamSlug,
 			Purpose:            " some purpose ",
-			SlackAlertsChannel: &slackChannel,
+			SlackAlertsChannel: slackChannel,
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, createdTeam.Slug, returnedTeam.Slug)
@@ -129,7 +129,7 @@ func TestMutationResolver_CreateTeam(t *testing.T) {
 		dbtx := db.NewMockDatabase(t)
 
 		dbtx.
-			On("CreateTeam", txCtx, teamSlug, "some purpose", &slackChannel).
+			On("CreateTeam", txCtx, teamSlug, "some purpose", slackChannel).
 			Return(createdTeam, nil).
 			Once()
 
@@ -158,7 +158,7 @@ func TestMutationResolver_CreateTeam(t *testing.T) {
 		returnedTeam, err := resolver.CreateTeam(saCtx, model.CreateTeamInput{
 			Slug:               &teamSlug,
 			Purpose:            " some purpose ",
-			SlackAlertsChannel: &slackChannel,
+			SlackAlertsChannel: slackChannel,
 		})
 
 		assert.NoError(t, err)

--- a/pkg/graph/teams_test.go
+++ b/pkg/graph/teams_test.go
@@ -60,11 +60,13 @@ func TestMutationResolver_CreateTeam(t *testing.T) {
 	assert.NoError(t, err)
 	resolver := graph.NewResolver(database, "example.com", reconcilers, auditLogger, gcpEnvironments, log).Mutation()
 	teamSlug := slug.Slug("some-slug")
+	slackChannel := "#my-slack-channel"
 
 	t.Run("create team with empty purpose", func(t *testing.T) {
 		_, err := resolver.CreateTeam(ctx, model.CreateTeamInput{
-			Slug:    &teamSlug,
-			Purpose: "  ",
+			Slug:               &teamSlug,
+			Purpose:            "  ",
+			SlackAlertsChannel: nil,
 		})
 		assert.ErrorContains(t, err, "You must specify the purpose for your team")
 	})
@@ -77,7 +79,7 @@ func TestMutationResolver_CreateTeam(t *testing.T) {
 		dbtx := db.NewMockDatabase(t)
 
 		dbtx.
-			On("CreateTeam", txCtx, teamSlug, "some purpose").
+			On("CreateTeam", txCtx, teamSlug, "some purpose", &slackChannel).
 			Return(createdTeam, nil).
 			Once()
 		dbtx.
@@ -108,8 +110,9 @@ func TestMutationResolver_CreateTeam(t *testing.T) {
 			Once()
 
 		returnedTeam, err := resolver.CreateTeam(ctx, model.CreateTeamInput{
-			Slug:    &teamSlug,
-			Purpose: " some purpose ",
+			Slug:               &teamSlug,
+			Purpose:            " some purpose ",
+			SlackAlertsChannel: &slackChannel,
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, createdTeam.Slug, returnedTeam.Slug)
@@ -126,7 +129,7 @@ func TestMutationResolver_CreateTeam(t *testing.T) {
 		dbtx := db.NewMockDatabase(t)
 
 		dbtx.
-			On("CreateTeam", txCtx, teamSlug, "some purpose").
+			On("CreateTeam", txCtx, teamSlug, "some purpose", &slackChannel).
 			Return(createdTeam, nil).
 			Once()
 
@@ -153,8 +156,9 @@ func TestMutationResolver_CreateTeam(t *testing.T) {
 			Once()
 
 		returnedTeam, err := resolver.CreateTeam(saCtx, model.CreateTeamInput{
-			Slug:    &teamSlug,
-			Purpose: " some purpose ",
+			Slug:               &teamSlug,
+			Purpose:            " some purpose ",
+			SlackAlertsChannel: &slackChannel,
 		})
 
 		assert.NoError(t, err)

--- a/pkg/legacy/filereader.go
+++ b/pkg/legacy/filereader.go
@@ -1,7 +1,6 @@
 package legacy
 
 import (
-	"database/sql"
 	"encoding/json"
 	"os"
 
@@ -27,19 +26,19 @@ type Team struct {
 }
 
 func (t *Team) Convert() *db.Team {
-	var slackAlertsChannel *string
+	var slackAlertsChannel string
 
 	if len(t.PlatformAlertsChannel) > 0 {
-		slackAlertsChannel = &t.PlatformAlertsChannel
+		slackAlertsChannel = t.PlatformAlertsChannel
 	} else if len(t.SlackChannel) > 0 {
-		slackAlertsChannel = &t.SlackChannel
+		slackAlertsChannel = t.SlackChannel
 	}
 
 	return &db.Team{
 		Team: &sqlc.Team{
 			Slug:               slug.Slug(t.Name),
 			Purpose:            t.Description,
-			SlackAlertsChannel: nullString(slackAlertsChannel),
+			SlackAlertsChannel: slackAlertsChannel,
 		},
 	}
 }
@@ -87,14 +86,4 @@ func ReadTeamFiles(ymlPath, jsonPath string, log logger.Logger) (map[string]*Tea
 	}
 
 	return teammap, nil
-}
-
-func nullString(s *string) sql.NullString {
-	if s == nil {
-		return sql.NullString{}
-	}
-	return sql.NullString{
-		String: *s,
-		Valid:  true,
-	}
 }

--- a/pkg/legacy/filereader.go
+++ b/pkg/legacy/filereader.go
@@ -3,6 +3,7 @@ package legacy
 import (
 	"encoding/json"
 	"os"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/nais/console/pkg/db"
@@ -38,7 +39,7 @@ func (t *Team) Convert() *db.Team {
 		Team: &sqlc.Team{
 			Slug:               slug.Slug(t.Name),
 			Purpose:            t.Description,
-			SlackAlertsChannel: slackAlertsChannel,
+			SlackAlertsChannel: strings.ToLower(slackAlertsChannel),
 		},
 	}
 }

--- a/pkg/sqlc/models.go
+++ b/pkg/sqlc/models.go
@@ -772,6 +772,7 @@ type Team struct {
 	Purpose            string
 	Enabled            bool
 	LastSuccessfulSync sql.NullTime
+	SlackAlertsChannel sql.NullString
 }
 
 type TeamMetadatum struct {

--- a/pkg/sqlc/models.go
+++ b/pkg/sqlc/models.go
@@ -772,7 +772,7 @@ type Team struct {
 	Purpose            string
 	Enabled            bool
 	LastSuccessfulSync sql.NullTime
-	SlackAlertsChannel sql.NullString
+	SlackAlertsChannel string
 }
 
 type TeamMetadatum struct {

--- a/pkg/sqlc/teams.sql.go
+++ b/pkg/sqlc/teams.sql.go
@@ -16,7 +16,7 @@ import (
 const createTeam = `-- name: CreateTeam :one
 INSERT INTO teams (slug, purpose)
 VALUES ($1, $2)
-RETURNING slug, purpose, enabled, last_successful_sync
+RETURNING slug, purpose, enabled, last_successful_sync, slack_alerts_channel
 `
 
 type CreateTeamParams struct {
@@ -32,6 +32,7 @@ func (q *Queries) CreateTeam(ctx context.Context, arg CreateTeamParams) (*Team, 
 		&i.Purpose,
 		&i.Enabled,
 		&i.LastSuccessfulSync,
+		&i.SlackAlertsChannel,
 	)
 	return &i, err
 }
@@ -40,7 +41,7 @@ const disableTeam = `-- name: DisableTeam :one
 UPDATE teams
 SET enabled = false
 WHERE slug = $1
-RETURNING slug, purpose, enabled, last_successful_sync
+RETURNING slug, purpose, enabled, last_successful_sync, slack_alerts_channel
 `
 
 func (q *Queries) DisableTeam(ctx context.Context, slug slug.Slug) (*Team, error) {
@@ -51,6 +52,7 @@ func (q *Queries) DisableTeam(ctx context.Context, slug slug.Slug) (*Team, error
 		&i.Purpose,
 		&i.Enabled,
 		&i.LastSuccessfulSync,
+		&i.SlackAlertsChannel,
 	)
 	return &i, err
 }
@@ -59,7 +61,7 @@ const enableTeam = `-- name: EnableTeam :one
 UPDATE teams
 SET enabled = true
 WHERE slug = $1
-RETURNING slug, purpose, enabled, last_successful_sync
+RETURNING slug, purpose, enabled, last_successful_sync, slack_alerts_channel
 `
 
 func (q *Queries) EnableTeam(ctx context.Context, slug slug.Slug) (*Team, error) {
@@ -70,12 +72,13 @@ func (q *Queries) EnableTeam(ctx context.Context, slug slug.Slug) (*Team, error)
 		&i.Purpose,
 		&i.Enabled,
 		&i.LastSuccessfulSync,
+		&i.SlackAlertsChannel,
 	)
 	return &i, err
 }
 
 const getTeamBySlug = `-- name: GetTeamBySlug :one
-SELECT slug, purpose, enabled, last_successful_sync FROM teams
+SELECT slug, purpose, enabled, last_successful_sync, slack_alerts_channel FROM teams
 WHERE slug = $1
 `
 
@@ -87,6 +90,7 @@ func (q *Queries) GetTeamBySlug(ctx context.Context, slug slug.Slug) (*Team, err
 		&i.Purpose,
 		&i.Enabled,
 		&i.LastSuccessfulSync,
+		&i.SlackAlertsChannel,
 	)
 	return &i, err
 }
@@ -151,7 +155,7 @@ func (q *Queries) GetTeamMetadata(ctx context.Context, teamSlug slug.Slug) ([]*T
 }
 
 const getTeams = `-- name: GetTeams :many
-SELECT slug, purpose, enabled, last_successful_sync FROM teams
+SELECT slug, purpose, enabled, last_successful_sync, slack_alerts_channel FROM teams
 ORDER BY slug ASC
 `
 
@@ -169,6 +173,7 @@ func (q *Queries) GetTeams(ctx context.Context) ([]*Team, error) {
 			&i.Purpose,
 			&i.Enabled,
 			&i.LastSuccessfulSync,
+			&i.SlackAlertsChannel,
 		); err != nil {
 			return nil, err
 		}
@@ -227,7 +232,7 @@ const updateTeam = `-- name: UpdateTeam :one
 UPDATE teams
 SET purpose = COALESCE($1, purpose)
 WHERE slug = $2
-RETURNING slug, purpose, enabled, last_successful_sync
+RETURNING slug, purpose, enabled, last_successful_sync, slack_alerts_channel
 `
 
 type UpdateTeamParams struct {
@@ -243,6 +248,7 @@ func (q *Queries) UpdateTeam(ctx context.Context, arg UpdateTeamParams) (*Team, 
 		&i.Purpose,
 		&i.Enabled,
 		&i.LastSuccessfulSync,
+		&i.SlackAlertsChannel,
 	)
 	return &i, err
 }

--- a/pkg/sqlc/teams.sql.go
+++ b/pkg/sqlc/teams.sql.go
@@ -22,7 +22,7 @@ RETURNING slug, purpose, enabled, last_successful_sync, slack_alerts_channel
 type CreateTeamParams struct {
 	Slug               slug.Slug
 	Purpose            string
-	SlackAlertsChannel sql.NullString
+	SlackAlertsChannel string
 }
 
 func (q *Queries) CreateTeam(ctx context.Context, arg CreateTeamParams) (*Team, error) {

--- a/pkg/sqlc/users.sql.go
+++ b/pkg/sqlc/users.sql.go
@@ -97,7 +97,7 @@ func (q *Queries) GetUserByID(ctx context.Context, id uuid.UUID) (*User, error) 
 }
 
 const getUserTeams = `-- name: GetUserTeams :many
-SELECT teams.slug, teams.purpose, teams.enabled, teams.last_successful_sync FROM user_roles
+SELECT teams.slug, teams.purpose, teams.enabled, teams.last_successful_sync, teams.slack_alerts_channel FROM user_roles
 JOIN teams ON teams.slug = user_roles.target_team_slug
 JOIN users ON users.id = user_roles.user_id
 WHERE user_roles.user_id = $1
@@ -118,6 +118,7 @@ func (q *Queries) GetUserTeams(ctx context.Context, userID uuid.UUID) ([]*Team, 
 			&i.Purpose,
 			&i.Enabled,
 			&i.LastSuccessfulSync,
+			&i.SlackAlertsChannel,
 		); err != nil {
 			return nil, err
 		}

--- a/sqlc/queries/teams.sql
+++ b/sqlc/queries/teams.sql
@@ -32,7 +32,7 @@ ON CONFLICT (team_slug, key) DO
 -- name: UpdateTeam :one
 UPDATE teams
 SET purpose = COALESCE(sqlc.narg(purpose), purpose),
-    slack_alerts_channel = COALESCE(sqlc.arg(slack_alerts_channel), slack_alerts_channel)
+    slack_alerts_channel = COALESCE(sqlc.narg(slack_alerts_channel), slack_alerts_channel)
 WHERE slug = sqlc.arg(slug)
 RETURNING *;
 

--- a/sqlc/queries/teams.sql
+++ b/sqlc/queries/teams.sql
@@ -1,6 +1,6 @@
 -- name: CreateTeam :one
-INSERT INTO teams (slug, purpose)
-VALUES ($1, $2)
+INSERT INTO teams (slug, purpose, slack_alerts_channel)
+VALUES ($1, $2, $3)
 RETURNING *;
 
 -- name: GetTeams :many
@@ -31,7 +31,8 @@ ON CONFLICT (team_slug, key) DO
 
 -- name: UpdateTeam :one
 UPDATE teams
-SET purpose = COALESCE(sqlc.narg(purpose), purpose)
+SET purpose = COALESCE(sqlc.narg(purpose), purpose),
+    slack_alerts_channel = COALESCE(sqlc.arg(slack_alerts_channel), slack_alerts_channel)
 WHERE slug = sqlc.arg(slug)
 RETURNING *;
 

--- a/sqlc/schemas/0031_slack_alerts_channel.down.sql
+++ b/sqlc/schemas/0031_slack_alerts_channel.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE teams DROP COLUMN slack_alerts_channel;
+
+COMMIT;

--- a/sqlc/schemas/0031_slack_alerts_channel.up.sql
+++ b/sqlc/schemas/0031_slack_alerts_channel.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE teams ADD COLUMN slack_alerts_channel TEXT;
+
+COMMIT;

--- a/sqlc/schemas/0031_slack_alerts_channel.up.sql
+++ b/sqlc/schemas/0031_slack_alerts_channel.up.sql
@@ -1,5 +1,5 @@
 BEGIN;
 
-ALTER TABLE teams ADD COLUMN slack_alerts_channel TEXT NOT NULL CONSTRAINT teams_slack_alerts_channel CHECK (slack_alerts_channel ~* '^#[a-z0-9æøå_-]{2,80}$');
+ALTER TABLE teams ADD COLUMN slack_alerts_channel TEXT NOT NULL CONSTRAINT teams_slack_alerts_channel CHECK (slack_alerts_channel ~ '^#[a-z0-9æøå_-]{2,80}$');
 
 COMMIT;

--- a/sqlc/schemas/0031_slack_alerts_channel.up.sql
+++ b/sqlc/schemas/0031_slack_alerts_channel.up.sql
@@ -1,5 +1,5 @@
 BEGIN;
 
-ALTER TABLE teams ADD COLUMN slack_alerts_channel TEXT;
+ALTER TABLE teams ADD COLUMN slack_alerts_channel TEXT CONSTRAINT teams_slack_alerts_channel CHECK (slack_alerts_channel ~* '^#[a-z0-9æøå_-]{2,80}$' OR slack_alerts_channel = '');
 
 COMMIT;

--- a/sqlc/schemas/0031_slack_alerts_channel.up.sql
+++ b/sqlc/schemas/0031_slack_alerts_channel.up.sql
@@ -1,5 +1,5 @@
 BEGIN;
 
-ALTER TABLE teams ADD COLUMN slack_alerts_channel TEXT CONSTRAINT teams_slack_alerts_channel CHECK (slack_alerts_channel ~* '^#[a-z0-9æøå_-]{2,80}$' OR slack_alerts_channel = '');
+ALTER TABLE teams ADD COLUMN slack_alerts_channel TEXT NOT NULL CONSTRAINT teams_slack_alerts_channel CHECK (slack_alerts_channel ~* '^#[a-z0-9æøå_-]{2,80}$');
 
 COMMIT;


### PR DESCRIPTION
Add a field to the team type for Slack alerts channels: `slackAlertsChannel`.