### PR TITLE
Create role that can skip the nais team slug validation

### DIFF
--- a/pkg/graph/model/validate.go
+++ b/pkg/graph/model/validate.go
@@ -19,7 +19,7 @@ func ptr[T any](value T) *T {
 	return &value
 }
 
-func (input CreateTeamInput) Validate() error {
+func (input CreateTeamInput) Validate(skipNaisValidation bool) error {
 	if input.Slug == nil || !teamSlugRegex.MatchString(string(*input.Slug)) || len(*input.Slug) < 3 || len(*input.Slug) > 30 {
 		return apierror.ErrTeamSlug
 	}
@@ -30,7 +30,7 @@ func (input CreateTeamInput) Validate() error {
 
 	slug := input.Slug.String()
 
-	if strings.HasPrefix(slug, "nais") {
+	if strings.HasPrefix(slug, "nais") && !skipNaisValidation {
 		return apierror.ErrTeamPrefixReserved
 	}
 

--- a/pkg/graph/model/validate_test.go
+++ b/pkg/graph/model/validate_test.go
@@ -35,12 +35,12 @@ func TestCreateTeamInput_Validate_SlackAlertsChannel(t *testing.T) {
 
 	for _, s := range validChannels {
 		tpl.SlackAlertsChannel = s
-		assert.NoError(t, tpl.Validate(), "Slack alerts channel %q should pass validation, but didn't", tpl.SlackAlertsChannel)
+		assert.NoError(t, tpl.Validate(false), "Slack alerts channel %q should pass validation, but didn't", tpl.SlackAlertsChannel)
 	}
 
 	for _, s := range invalidChannels {
 		tpl.SlackAlertsChannel = s
-		assert.Error(t, tpl.Validate(), "Slack alerts channel %q passed validation even if it should not", tpl.SlackAlertsChannel)
+		assert.Error(t, tpl.Validate(false), "Slack alerts channel %q passed validation even if it should not", tpl.SlackAlertsChannel)
 	}
 }
 
@@ -81,11 +81,57 @@ func TestCreateTeamInput_Validate_Slug(t *testing.T) {
 
 	for _, s := range validSlugs {
 		tpl.Slug = ptr(slug.Slug(s))
-		assert.NoError(t, tpl.Validate(), "Slug %q should pass validation, but didn't", tpl.Slug)
+		assert.NoError(t, tpl.Validate(false), "Slug %q should pass validation, but didn't", tpl.Slug)
 	}
 
 	for _, s := range invalidSlugs {
 		tpl.Slug = ptr(slug.Slug(s))
-		assert.Error(t, tpl.Validate(), "Slug %q passed validation even if it should not", tpl.Slug)
+		assert.Error(t, tpl.Validate(false), "Slug %q passed validation even if it should not", tpl.Slug)
+	}
+}
+
+func TestCreateTeamInput_Validate_NaisSlug(t *testing.T) {
+	tpl := model.CreateTeamInput{
+		Slug:               nil,
+		Purpose:            "valid purpose",
+		SlackAlertsChannel: "#channel",
+	}
+
+	validSlugs := []string{
+		"foo",
+		"foo-bar",
+		"f00b4r",
+		"channel4",
+		"some-long-string-less-than-31c",
+		"nais",
+		"nais-system",
+		"naisuratur",
+		"naisan",
+	}
+
+	invalidSlugs := []string{
+		"a",
+		"ab",
+		"-foo",
+		"foo-",
+		"foo--bar",
+		"4chan",
+		"team",
+		"team-foo",
+		"teamfoobar",
+		"some-long-string-more-than-30-chars",
+		"you-aint-got-the-æøå",
+		"Uppercase",
+		"rollback()",
+	}
+
+	for _, s := range validSlugs {
+		tpl.Slug = ptr(slug.Slug(s))
+		assert.NoError(t, tpl.Validate(true), "Slug %q should pass validation, but didn't", tpl.Slug)
+	}
+
+	for _, s := range invalidSlugs {
+		tpl.Slug = ptr(slug.Slug(s))
+		assert.Error(t, tpl.Validate(true), "Slug %q passed validation even if it should not", tpl.Slug)
 	}
 }

--- a/pkg/graph/teams.go
+++ b/pkg/graph/teams.go
@@ -29,9 +29,12 @@ func (r *mutationResolver) CreateTeam(ctx context.Context, input model.CreateTea
 		return nil, err
 	}
 
+	err = authz.RequireGlobalAuthorization(actor, sqlc.AuthzNameTeamsSkipNaisValidation)
+	skipNaisValidation := err != nil
+
 	input = input.Sanitize()
 
-	err = input.Validate()
+	err = input.Validate(skipNaisValidation)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sqlc/models.go
+++ b/pkg/sqlc/models.go
@@ -296,24 +296,25 @@ func AllAuditLogsTargetTypeValues() []AuditLogsTargetType {
 type AuthzName string
 
 const (
-	AuthzNameAuditLogsRead         AuthzName = "audit_logs:read"
-	AuthzNameServiceAccountsCreate AuthzName = "service_accounts:create"
-	AuthzNameServiceAccountsDelete AuthzName = "service_accounts:delete"
-	AuthzNameServiceAccountsList   AuthzName = "service_accounts:list"
-	AuthzNameServiceAccountsRead   AuthzName = "service_accounts:read"
-	AuthzNameServiceAccountsUpdate AuthzName = "service_accounts:update"
-	AuthzNameSystemStatesDelete    AuthzName = "system_states:delete"
-	AuthzNameSystemStatesRead      AuthzName = "system_states:read"
-	AuthzNameSystemStatesUpdate    AuthzName = "system_states:update"
-	AuthzNameTeamsCreate           AuthzName = "teams:create"
-	AuthzNameTeamsDelete           AuthzName = "teams:delete"
-	AuthzNameTeamsList             AuthzName = "teams:list"
-	AuthzNameTeamsRead             AuthzName = "teams:read"
-	AuthzNameTeamsUpdate           AuthzName = "teams:update"
-	AuthzNameUsersList             AuthzName = "users:list"
-	AuthzNameUsersUpdate           AuthzName = "users:update"
-	AuthzNameTeamsSynchronize      AuthzName = "teams:synchronize"
-	AuthzNameUsersyncSynchronize   AuthzName = "usersync:synchronize"
+	AuthzNameAuditLogsRead           AuthzName = "audit_logs:read"
+	AuthzNameServiceAccountsCreate   AuthzName = "service_accounts:create"
+	AuthzNameServiceAccountsDelete   AuthzName = "service_accounts:delete"
+	AuthzNameServiceAccountsList     AuthzName = "service_accounts:list"
+	AuthzNameServiceAccountsRead     AuthzName = "service_accounts:read"
+	AuthzNameServiceAccountsUpdate   AuthzName = "service_accounts:update"
+	AuthzNameSystemStatesDelete      AuthzName = "system_states:delete"
+	AuthzNameSystemStatesRead        AuthzName = "system_states:read"
+	AuthzNameSystemStatesUpdate      AuthzName = "system_states:update"
+	AuthzNameTeamsCreate             AuthzName = "teams:create"
+	AuthzNameTeamsDelete             AuthzName = "teams:delete"
+	AuthzNameTeamsList               AuthzName = "teams:list"
+	AuthzNameTeamsRead               AuthzName = "teams:read"
+	AuthzNameTeamsUpdate             AuthzName = "teams:update"
+	AuthzNameUsersList               AuthzName = "users:list"
+	AuthzNameUsersUpdate             AuthzName = "users:update"
+	AuthzNameTeamsSynchronize        AuthzName = "teams:synchronize"
+	AuthzNameUsersyncSynchronize     AuthzName = "usersync:synchronize"
+	AuthzNameTeamsSkipNaisValidation AuthzName = "teams:skip_nais_validation"
 )
 
 func (e *AuthzName) Scan(src interface{}) error {
@@ -370,7 +371,8 @@ func (e AuthzName) Valid() bool {
 		AuthzNameUsersList,
 		AuthzNameUsersUpdate,
 		AuthzNameTeamsSynchronize,
-		AuthzNameUsersyncSynchronize:
+		AuthzNameUsersyncSynchronize,
+		AuthzNameTeamsSkipNaisValidation:
 		return true
 	}
 	return false
@@ -396,6 +398,7 @@ func AllAuthzNameValues() []AuthzName {
 		AuthzNameUsersUpdate,
 		AuthzNameTeamsSynchronize,
 		AuthzNameUsersyncSynchronize,
+		AuthzNameTeamsSkipNaisValidation,
 	}
 }
 
@@ -555,6 +558,7 @@ const (
 	RoleNameUseradmin             RoleName = "User admin"
 	RoleNameUserviewer            RoleName = "User viewer"
 	RoleNameSynchronizer          RoleName = "Synchronizer"
+	RoleNameNaisTeamcreator       RoleName = "NaisTeam creator"
 )
 
 func (e *RoleName) Scan(src interface{}) error {
@@ -603,7 +607,8 @@ func (e RoleName) Valid() bool {
 		RoleNameTeamviewer,
 		RoleNameUseradmin,
 		RoleNameUserviewer,
-		RoleNameSynchronizer:
+		RoleNameSynchronizer,
+		RoleNameNaisTeamcreator:
 		return true
 	}
 	return false
@@ -621,6 +626,7 @@ func AllRoleNameValues() []RoleName {
 		RoleNameUseradmin,
 		RoleNameUserviewer,
 		RoleNameSynchronizer,
+		RoleNameNaisTeamcreator,
 	}
 }
 

--- a/sqlc/schemas/0036_add_nais_creator.down.sql
+++ b/sqlc/schemas/0036_add_nais_creator.down.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+/* PostgreSQL does not support removing single items from an ENUM, one must DROP the type, and re-create it */
+
+DELETE FROM role_authz WHERE
+  (role_name='NaisTeam creator' AND authz_name='teams:skip_nais_validation') OR
+  (role_name='NaisTeam creator' AND authz_name='teams:create')
+    ;
+
+COMMIT;

--- a/sqlc/schemas/0036_add_nais_creator.up.sql
+++ b/sqlc/schemas/0036_add_nais_creator.up.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+ALTER TYPE role_name ADD VALUE IF NOT EXISTS 'NaisTeam creator';
+ALTER TYPE authz_name ADD VALUE IF NOT EXISTS 'teams:skip_nais_validation';
+
+COMMIT;
+BEGIN;
+INSERT INTO role_authz(role_name, authz_name) VALUES
+    ('NaisTeam creator','teams:skip_nais_validation'),
+    ('NaisTeam creator','teams:create');
+
+COMMIT;


### PR DESCRIPTION
This allows the creation of teams named `nais*` using the API, which is needed by nais-verification.

Suggestions for better role_name and/or authz_name welcome. :slightly_smiling_face: 
