### PR TITLE
Change how Slack alerts channels work

### DIFF
--- a/cmd/console/main.go
+++ b/cmd/console/main.go
@@ -131,17 +131,12 @@ func run(cfg *config.Config, log logger.Logger) error {
 		return err
 	}
 
-	gcpEnvironments := make([]string, 0, len(cfg.GCP.Clusters))
-	for environment := range cfg.GCP.Clusters {
-		gcpEnvironments = append(gcpEnvironments, environment)
-	}
-
 	deployProxy, err := nais_deploy_reconciler.NewProxy(cfg.NaisDeploy.DeployKeyEndpoint, cfg.NaisDeploy.ProvisionKey, log)
 	if err != nil {
 		log.Warnf("Deploy proxy is not configured: %v", err)
 	}
 
-	handler := setupGraphAPI(database, deployProxy, cfg.TenantDomain, teamReconciler, userSync, auditLogger.WithSystemName(sqlc.SystemNameGraphqlApi), gcpEnvironments, log)
+	handler := setupGraphAPI(database, deployProxy, cfg.TenantDomain, teamReconciler, userSync, auditLogger.WithSystemName(sqlc.SystemNameGraphqlApi), cfg.Environments, log)
 	srv, err := setupHTTPServer(cfg, database, handler, authHandler)
 	if err != nil {
 		return err

--- a/graphql/teams.graphqls
+++ b/graphql/teams.graphqls
@@ -19,7 +19,8 @@ extend type Mutation {
     """
     Create a new team
 
-    The user creating the team will be granted team ownership, unless the user is a service account, in which case the team will not get an initial owner. To add one or more owners to the team, refer to the `addTeamOwners` mutation.
+    The user creating the team will be granted team ownership, unless the user is a service account, in which case the
+    team will not get an initial owner. To add one or more owners to the team, refer to the `addTeamOwners` mutation.
 
     The new team will be returned on success.
     """
@@ -189,7 +190,19 @@ type Team {
     reconcilerState: ReconcilerState!
 
     "Slack channel for the team."
-    slackChannel: String
+    slackChannel: String!
+
+    "A list of Slack channels for NAIS alerts. If no channel is specified for a given environment, NAIS will fallback to the slackChannel value."
+    slackAlertsChannels: [SlackAlertsChannel!]!
+}
+
+"Slack alerts channel type."
+type SlackAlertsChannel {
+    "The environment for the alerts sent to the channel."
+    environment: String!
+
+    "The name of the Slack channel."
+    channelName: String
 }
 
 "Reconciler state type."
@@ -292,6 +305,18 @@ input UpdateTeamInput {
 
     "Specify the Slack channel to update the existing value."
     slackChannel: String
+
+    "A list of Slack channels for NAIS alerts."
+    slackAlertsChannels: [SlackAlertsChannelInput!]
+}
+
+"Slack alerts channel input."
+input SlackAlertsChannelInput {
+    "The environment for the alerts sent to the channel."
+    environment: String!
+
+    "The name of the Slack channel."
+    channelName: String
 }
 
 "Available team roles."

--- a/graphql/teams.graphqls
+++ b/graphql/teams.graphqls
@@ -188,8 +188,8 @@ type Team {
     "Current reconciler state for the team."
     reconcilerState: ReconcilerState!
 
-    "Slack channel for NAIS alerts."
-    slackAlertsChannel: String
+    "Slack channel for the team."
+    slackChannel: String
 }
 
 "Reconciler state type."
@@ -281,8 +281,8 @@ input CreateTeamInput {
     "Team purpose."
     purpose: String!
 
-    "Specify the Slack channel where NAIS alerts will be sent."
-    slackAlertsChannel: String!
+    "Specify the Slack channel for the team."
+    slackChannel: String!
 }
 
 "Input for updating an existing team."
@@ -291,7 +291,7 @@ input UpdateTeamInput {
     purpose: String
 
     "Specify the Slack channel to update the existing value."
-    slackAlertsChannel: String
+    slackChannel: String
 }
 
 "Available team roles."

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -74,6 +74,9 @@ type Config struct {
 	NaisNamespace NaisNamespace
 	OAuth         OAuth
 
+	// Environments A list of environment names used for instance in GCP
+	Environments []string
+
 	// DatabaseURL The URL for the database.
 	//
 	// Example: `postgres://console:console@localhost:3002/console?sslmode=disable`
@@ -167,13 +170,25 @@ func New() (*Config, error) {
 		return nil, err
 	}
 
+	environments := make([]string, 0)
 	if strings.ToLower(cfg.TenantName) == "nav" {
 		cfg.LegacyClusters = map[string]string{
 			"dev-gcp":  "nais-dev-2e7b",
 			"prod-gcp": "nais-prod-020f",
 			"ci-gcp":   "nais-ci-e17f",
 		}
+
+		for _, mapping := range cfg.LegacyNaisNamespaces {
+			environments = append(environments, mapping.Virtual)
+		}
+
+	} else {
+		for environment := range cfg.GCP.Clusters {
+			environments = append(environments, environment)
+		}
 	}
+
+	cfg.Environments = environments
 
 	return cfg, nil
 }

--- a/pkg/db/mock_database.go
+++ b/pkg/db/mock_database.go
@@ -650,6 +650,29 @@ func (_m *MockDatabase) GetSessionByID(ctx context.Context, sessionID uuid.UUID)
 	return r0, r1
 }
 
+// GetSlackAlertsChannels provides a mock function with given fields: ctx, teamSlug
+func (_m *MockDatabase) GetSlackAlertsChannels(ctx context.Context, teamSlug slug.Slug) (map[string]string, error) {
+	ret := _m.Called(ctx, teamSlug)
+
+	var r0 map[string]string
+	if rf, ok := ret.Get(0).(func(context.Context, slug.Slug) map[string]string); ok {
+		r0 = rf(ctx, teamSlug)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]string)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, slug.Slug) error); ok {
+		r1 = rf(ctx, teamSlug)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetTeamBySlug provides a mock function with given fields: ctx, _a1
 func (_m *MockDatabase) GetTeamBySlug(ctx context.Context, _a1 slug.Slug) (*Team, error) {
 	ret := _m.Called(ctx, _a1)
@@ -989,6 +1012,20 @@ func (_m *MockDatabase) RemoveApiKeysFromServiceAccount(ctx context.Context, ser
 	return r0
 }
 
+// RemoveSlackAlertsChannel provides a mock function with given fields: ctx, teamSlug, environment
+func (_m *MockDatabase) RemoveSlackAlertsChannel(ctx context.Context, teamSlug slug.Slug, environment string) error {
+	ret := _m.Called(ctx, teamSlug, environment)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, slug.Slug, string) error); ok {
+		r0 = rf(ctx, teamSlug, environment)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // RemoveUserFromTeam provides a mock function with given fields: ctx, userID, teamSlug
 func (_m *MockDatabase) RemoveUserFromTeam(ctx context.Context, userID uuid.UUID, teamSlug slug.Slug) error {
 	ret := _m.Called(ctx, userID, teamSlug)
@@ -1075,6 +1112,20 @@ func (_m *MockDatabase) SetReconcilerStateForTeam(ctx context.Context, reconcile
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, sqlc.ReconcilerName, slug.Slug, interface{}) error); ok {
 		r0 = rf(ctx, reconcilerName, _a2, state)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// SetSlackAlertsChannel provides a mock function with given fields: ctx, teamSlug, environment, channelName
+func (_m *MockDatabase) SetSlackAlertsChannel(ctx context.Context, teamSlug slug.Slug, environment string, channelName string) error {
+	ret := _m.Called(ctx, teamSlug, environment, channelName)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, slug.Slug, string, string) error); ok {
+		r0 = rf(ctx, teamSlug, environment, channelName)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/pkg/db/mock_database.go
+++ b/pkg/db/mock_database.go
@@ -157,13 +157,13 @@ func (_m *MockDatabase) CreateSession(ctx context.Context, userID uuid.UUID) (*S
 	return r0, r1
 }
 
-// CreateTeam provides a mock function with given fields: ctx, _a1, purpose, slackAlertsChannel
-func (_m *MockDatabase) CreateTeam(ctx context.Context, _a1 slug.Slug, purpose string, slackAlertsChannel string) (*Team, error) {
-	ret := _m.Called(ctx, _a1, purpose, slackAlertsChannel)
+// CreateTeam provides a mock function with given fields: ctx, _a1, purpose, slackChannel
+func (_m *MockDatabase) CreateTeam(ctx context.Context, _a1 slug.Slug, purpose string, slackChannel string) (*Team, error) {
+	ret := _m.Called(ctx, _a1, purpose, slackChannel)
 
 	var r0 *Team
 	if rf, ok := ret.Get(0).(func(context.Context, slug.Slug, string, string) *Team); ok {
-		r0 = rf(ctx, _a1, purpose, slackAlertsChannel)
+		r0 = rf(ctx, _a1, purpose, slackChannel)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*Team)
@@ -172,7 +172,7 @@ func (_m *MockDatabase) CreateTeam(ctx context.Context, _a1 slug.Slug, purpose s
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, slug.Slug, string, string) error); ok {
-		r1 = rf(ctx, _a1, purpose, slackAlertsChannel)
+		r1 = rf(ctx, _a1, purpose, slackChannel)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1124,13 +1124,13 @@ func (_m *MockDatabase) Transaction(ctx context.Context, fn DatabaseTransactionF
 	return r0
 }
 
-// UpdateTeam provides a mock function with given fields: ctx, teamSlug, purpose, slackAlertsChannel
-func (_m *MockDatabase) UpdateTeam(ctx context.Context, teamSlug slug.Slug, purpose *string, slackAlertsChannel *string) (*Team, error) {
-	ret := _m.Called(ctx, teamSlug, purpose, slackAlertsChannel)
+// UpdateTeam provides a mock function with given fields: ctx, teamSlug, purpose, slackChannel
+func (_m *MockDatabase) UpdateTeam(ctx context.Context, teamSlug slug.Slug, purpose *string, slackChannel *string) (*Team, error) {
+	ret := _m.Called(ctx, teamSlug, purpose, slackChannel)
 
 	var r0 *Team
 	if rf, ok := ret.Get(0).(func(context.Context, slug.Slug, *string, *string) *Team); ok {
-		r0 = rf(ctx, teamSlug, purpose, slackAlertsChannel)
+		r0 = rf(ctx, teamSlug, purpose, slackChannel)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*Team)
@@ -1139,7 +1139,7 @@ func (_m *MockDatabase) UpdateTeam(ctx context.Context, teamSlug slug.Slug, purp
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, slug.Slug, *string, *string) error); ok {
-		r1 = rf(ctx, teamSlug, purpose, slackAlertsChannel)
+		r1 = rf(ctx, teamSlug, purpose, slackChannel)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/db/team.go
+++ b/pkg/db/team.go
@@ -151,3 +151,32 @@ func (d *database) EnableTeam(ctx context.Context, teamSlug slug.Slug) (*Team, e
 func (d *database) SetLastSuccessfulSyncForTeam(ctx context.Context, teamSlug slug.Slug) error {
 	return d.querier.SetLastSuccessfulSyncForTeam(ctx, teamSlug)
 }
+
+func (d *database) GetSlackAlertsChannels(ctx context.Context, teamSlug slug.Slug) (map[string]string, error) {
+	channels := make(map[string]string)
+	rows, err := d.querier.GetSlackAlertsChannels(ctx, teamSlug)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, row := range rows {
+		channels[row.Environment] = row.ChannelName
+	}
+
+	return channels, nil
+}
+
+func (d *database) SetSlackAlertsChannel(ctx context.Context, teamSlug slug.Slug, environment, channelName string) error {
+	return d.querier.SetSlackAlertsChannel(ctx, sqlc.SetSlackAlertsChannelParams{
+		TeamSlug:    teamSlug,
+		Environment: environment,
+		ChannelName: channelName,
+	})
+}
+
+func (d *database) RemoveSlackAlertsChannel(ctx context.Context, teamSlug slug.Slug, environment string) error {
+	return d.querier.RemoveSlackAlertsChannel(ctx, sqlc.RemoveSlackAlertsChannelParams{
+		TeamSlug:    teamSlug,
+		Environment: environment,
+	})
+}

--- a/pkg/db/team.go
+++ b/pkg/db/team.go
@@ -53,11 +53,11 @@ func (d *database) RemoveUserFromTeam(ctx context.Context, userID uuid.UUID, tea
 	})
 }
 
-func (d *database) UpdateTeam(ctx context.Context, teamSlug slug.Slug, purpose, slackAlertsChannel *string) (*Team, error) {
+func (d *database) UpdateTeam(ctx context.Context, teamSlug slug.Slug, purpose, slackChannel *string) (*Team, error) {
 	team, err := d.querier.UpdateTeam(ctx, sqlc.UpdateTeamParams{
-		Slug:               teamSlug,
-		Purpose:            nullString(purpose),
-		SlackAlertsChannel: nullString(slackAlertsChannel),
+		Slug:         teamSlug,
+		Purpose:      nullString(purpose),
+		SlackChannel: nullString(slackChannel),
 	})
 	if err != nil {
 		return nil, err
@@ -66,11 +66,11 @@ func (d *database) UpdateTeam(ctx context.Context, teamSlug slug.Slug, purpose, 
 	return &Team{Team: team}, nil
 }
 
-func (d *database) CreateTeam(ctx context.Context, slug slug.Slug, purpose, slackAlertsChannel string) (*Team, error) {
+func (d *database) CreateTeam(ctx context.Context, slug slug.Slug, purpose, slackChannel string) (*Team, error) {
 	team, err := d.querier.CreateTeam(ctx, sqlc.CreateTeamParams{
-		Slug:               slug,
-		Purpose:            purpose,
-		SlackAlertsChannel: slackAlertsChannel,
+		Slug:         slug,
+		Purpose:      purpose,
+		SlackChannel: slackChannel,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/db/types.go
+++ b/pkg/db/types.go
@@ -102,10 +102,10 @@ type Database interface {
 	DeleteUser(ctx context.Context, userID uuid.UUID) error
 	GetUsers(ctx context.Context) ([]*User, error)
 	GetUserTeams(ctx context.Context, userID uuid.UUID) ([]*Team, error)
-	CreateTeam(ctx context.Context, slug slug.Slug, purpose, slackAlertsChannel string) (*Team, error)
+	CreateTeam(ctx context.Context, slug slug.Slug, purpose, slackChannel string) (*Team, error)
 	SetTeamMetadata(ctx context.Context, slug slug.Slug, metadata []TeamMetadata) error
 	GetTeamMetadata(ctx context.Context, slug slug.Slug) ([]*TeamMetadata, error)
-	UpdateTeam(ctx context.Context, teamSlug slug.Slug, purpose, slackAlertsChannel *string) (*Team, error)
+	UpdateTeam(ctx context.Context, teamSlug slug.Slug, purpose, slackChannel *string) (*Team, error)
 	GetTeamBySlug(ctx context.Context, slug slug.Slug) (*Team, error)
 	GetTeams(ctx context.Context) ([]*Team, error)
 	GetTeamMembers(ctx context.Context, teamSlug slug.Slug) ([]*User, error)

--- a/pkg/db/types.go
+++ b/pkg/db/types.go
@@ -151,6 +151,9 @@ type Database interface {
 	GetUsersWithGloballyAssignedRole(ctx context.Context, roleName sqlc.RoleName) ([]*User, error)
 	IsFirstRun(ctx context.Context) (bool, error)
 	FirstRunComplete(ctx context.Context) error
+	GetSlackAlertsChannels(ctx context.Context, teamSlug slug.Slug) (map[string]string, error)
+	SetSlackAlertsChannel(ctx context.Context, teamSlug slug.Slug, environment, channelName string) error
+	RemoveSlackAlertsChannel(ctx context.Context, teamSlug slug.Slug, environment string) error
 }
 
 func (u User) GetID() uuid.UUID {

--- a/pkg/fixtures/naisteam.go
+++ b/pkg/fixtures/naisteam.go
@@ -8,16 +8,16 @@ import (
 )
 
 const (
-	Slug               = "nais-verification"
-	Purpose            = "A place for NAIS to run verification workloads"
-	SlackAlertsChannel = "#nais-alerts-prod"
+	slug         = "nais-verification"
+	purpose      = "A place for NAIS to run verification workloads"
+	slackChannel = "#nais-alerts-prod"
 )
 
 func CreateNaisVerification(ctx context.Context, database db.Database) error {
-	_, err := database.GetTeamBySlug(ctx, Slug)
+	_, err := database.GetTeamBySlug(ctx, slug)
 	if err != nil {
 		if err == pgx.ErrNoRows {
-			_, err = database.CreateTeam(ctx, Slug, Purpose, SlackAlertsChannel)
+			_, err = database.CreateTeam(ctx, slug, purpose, slackChannel)
 		}
 	}
 

--- a/pkg/graph/apierror/errors.go
+++ b/pkg/graph/apierror/errors.go
@@ -16,7 +16,6 @@ import (
 
 var (
 	ErrTeamSlug            = Errorf("Your team identifier does not fit our requirements. Team identifiers must contain only lowercase alphanumeric characters or hyphens, contain at least 3 characters and at most 30 characters, start with an alphabetic character, end with an alphanumeric character, and not contain two hyphens in a row.")
-	ErrTeamSlackChannel    = Errorf("The Slack channel does not fit the requirements. The name must contain at least 2 characters and at most 80 characters. The name must consist of lowercase letters, numbers, hyphens and underscores, and it must be prefixed with a hash symbol.")
 	ErrInternal            = Errorf("The server errored out while processing your request, and we didn't write a suitable error message. You might consider that a bug on our side. Please try again, and if the error persists, contact the NAIS team.")
 	ErrDatabase            = Errorf("The database system encountered an error while processing your request. This is probably a transient error, please try again. If the error persists, contact the NAIS team.")
 	ErrTeamPurpose         = Errorf("You must specify the purpose for your team. This is a human-readable string which is used in external systems, and is important because other people might need to to understand what your team is all about.")

--- a/pkg/graph/apierror/errors.go
+++ b/pkg/graph/apierror/errors.go
@@ -15,13 +15,13 @@ import (
 )
 
 var (
-	ErrTeamSlug               = Errorf("Your team identifier does not fit our requirements. Team identifiers must contain only lowercase alphanumeric characters or hyphens, contain at least 3 characters and at most 30 characters, start with an alphabetic character, end with an alphanumeric character, and not contain two hyphens in a row.")
-	ErrTeamSlackAlertsChannel = Errorf("The Slack alerts channel does not fit the requirements. The name must contain at least 2 characters and at most 80 characters. The name must consist of lowercase letters, numbers, hyphens and underscores, and it must be prefixed with a hash symbol.")
-	ErrInternal               = Errorf("The server errored out while processing your request, and we didn't write a suitable error message. You might consider that a bug on our side. Please try again, and if the error persists, contact the NAIS team.")
-	ErrDatabase               = Errorf("The database system encountered an error while processing your request. This is probably a transient error, please try again. If the error persists, contact the NAIS team.")
-	ErrTeamPurpose            = Errorf("You must specify the purpose for your team. This is a human-readable string which is used in external systems, and is important because other people might need to to understand what your team is all about.")
-	ErrTeamNotExist           = Errorf("The team you are referring to does not exist in our database.")
-	ErrTeamPrefixRedundant    = Errorf("The name prefix 'team' is redundant. When you create a team, it is by definition a team. Try again with a different name, perhaps just removing the prefix?")
+	ErrTeamSlug            = Errorf("Your team identifier does not fit our requirements. Team identifiers must contain only lowercase alphanumeric characters or hyphens, contain at least 3 characters and at most 30 characters, start with an alphabetic character, end with an alphanumeric character, and not contain two hyphens in a row.")
+	ErrTeamSlackChannel    = Errorf("The Slack channel does not fit the requirements. The name must contain at least 2 characters and at most 80 characters. The name must consist of lowercase letters, numbers, hyphens and underscores, and it must be prefixed with a hash symbol.")
+	ErrInternal            = Errorf("The server errored out while processing your request, and we didn't write a suitable error message. You might consider that a bug on our side. Please try again, and if the error persists, contact the NAIS team.")
+	ErrDatabase            = Errorf("The database system encountered an error while processing your request. This is probably a transient error, please try again. If the error persists, contact the NAIS team.")
+	ErrTeamPurpose         = Errorf("You must specify the purpose for your team. This is a human-readable string which is used in external systems, and is important because other people might need to to understand what your team is all about.")
+	ErrTeamNotExist        = Errorf("The team you are referring to does not exist in our database.")
+	ErrTeamPrefixRedundant = Errorf("The name prefix 'team' is redundant. When you create a team, it is by definition a team. Try again with a different name, perhaps just removing the prefix?")
 )
 
 type Error struct {

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -158,6 +158,11 @@ type ComplexityRoot struct {
 		Roles func(childComplexity int) int
 	}
 
+	SlackAlertsChannel struct {
+		ChannelName func(childComplexity int) int
+		Environment func(childComplexity int) int
+	}
+
 	SyncError struct {
 		CreatedAt  func(childComplexity int) int
 		Error      func(childComplexity int) int
@@ -165,16 +170,17 @@ type ComplexityRoot struct {
 	}
 
 	Team struct {
-		AuditLogs          func(childComplexity int) int
-		Enabled            func(childComplexity int) int
-		LastSuccessfulSync func(childComplexity int) int
-		Members            func(childComplexity int) int
-		Metadata           func(childComplexity int) int
-		Purpose            func(childComplexity int) int
-		ReconcilerState    func(childComplexity int) int
-		SlackChannel       func(childComplexity int) int
-		Slug               func(childComplexity int) int
-		SyncErrors         func(childComplexity int) int
+		AuditLogs           func(childComplexity int) int
+		Enabled             func(childComplexity int) int
+		LastSuccessfulSync  func(childComplexity int) int
+		Members             func(childComplexity int) int
+		Metadata            func(childComplexity int) int
+		Purpose             func(childComplexity int) int
+		ReconcilerState     func(childComplexity int) int
+		SlackAlertsChannels func(childComplexity int) int
+		SlackChannel        func(childComplexity int) int
+		Slug                func(childComplexity int) int
+		SyncErrors          func(childComplexity int) int
 	}
 
 	TeamMember struct {
@@ -269,6 +275,8 @@ type TeamResolver interface {
 
 	LastSuccessfulSync(ctx context.Context, obj *db.Team) (*time.Time, error)
 	ReconcilerState(ctx context.Context, obj *db.Team) (*model.ReconcilerState, error)
+
+	SlackAlertsChannels(ctx context.Context, obj *db.Team) ([]*model.SlackAlertsChannel, error)
 }
 type UserResolver interface {
 	Teams(ctx context.Context, obj *db.User) ([]*model.TeamMembership, error)
@@ -890,6 +898,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.ServiceAccount.Roles(childComplexity), true
 
+	case "SlackAlertsChannel.channelName":
+		if e.complexity.SlackAlertsChannel.ChannelName == nil {
+			break
+		}
+
+		return e.complexity.SlackAlertsChannel.ChannelName(childComplexity), true
+
+	case "SlackAlertsChannel.environment":
+		if e.complexity.SlackAlertsChannel.Environment == nil {
+			break
+		}
+
+		return e.complexity.SlackAlertsChannel.Environment(childComplexity), true
+
 	case "SyncError.createdAt":
 		if e.complexity.SyncError.CreatedAt == nil {
 			break
@@ -959,6 +981,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Team.ReconcilerState(childComplexity), true
+
+	case "Team.slackAlertsChannels":
+		if e.complexity.Team.SlackAlertsChannels == nil {
+			break
+		}
+
+		return e.complexity.Team.SlackAlertsChannels(childComplexity), true
 
 	case "Team.slackChannel":
 		if e.complexity.Team.SlackChannel == nil {
@@ -1089,6 +1118,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	inputUnmarshalMap := graphql.BuildUnmarshalerMap(
 		ec.unmarshalInputCreateTeamInput,
 		ec.unmarshalInputReconcilerConfigInput,
+		ec.unmarshalInputSlackAlertsChannelInput,
 		ec.unmarshalInputUpdateTeamInput,
 	)
 	first := true
@@ -1441,7 +1471,8 @@ extend type Mutation {
     """
     Create a new team
 
-    The user creating the team will be granted team ownership, unless the user is a service account, in which case the team will not get an initial owner. To add one or more owners to the team, refer to the ` + "`" + `addTeamOwners` + "`" + ` mutation.
+    The user creating the team will be granted team ownership, unless the user is a service account, in which case the
+    team will not get an initial owner. To add one or more owners to the team, refer to the ` + "`" + `addTeamOwners` + "`" + ` mutation.
 
     The new team will be returned on success.
     """
@@ -1611,7 +1642,19 @@ type Team {
     reconcilerState: ReconcilerState!
 
     "Slack channel for the team."
-    slackChannel: String
+    slackChannel: String!
+
+    "A list of Slack channels for NAIS alerts. If no channel is specified for a given environment, NAIS will fallback to the slackChannel value."
+    slackAlertsChannels: [SlackAlertsChannel!]!
+}
+
+"Slack alerts channel type."
+type SlackAlertsChannel {
+    "The environment for the alerts sent to the channel."
+    environment: String!
+
+    "The name of the Slack channel."
+    channelName: String
 }
 
 "Reconciler state type."
@@ -1714,6 +1757,18 @@ input UpdateTeamInput {
 
     "Specify the Slack channel to update the existing value."
     slackChannel: String
+
+    "A list of Slack channels for NAIS alerts."
+    slackAlertsChannels: [SlackAlertsChannelInput!]
+}
+
+"Slack alerts channel input."
+input SlackAlertsChannelInput {
+    "The environment for the alerts sent to the channel."
+    environment: String!
+
+    "The name of the Slack channel."
+    channelName: String
 }
 
 "Available team roles."
@@ -2896,6 +2951,8 @@ func (ec *executionContext) fieldContext_Mutation_setGitHubTeamSlug(ctx context.
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
 			case "slackChannel":
 				return ec.fieldContext_Team_slackChannel(ctx, field)
+			case "slackAlertsChannels":
+				return ec.fieldContext_Team_slackAlertsChannels(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -2993,6 +3050,8 @@ func (ec *executionContext) fieldContext_Mutation_setGoogleWorkspaceGroupEmail(c
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
 			case "slackChannel":
 				return ec.fieldContext_Team_slackChannel(ctx, field)
+			case "slackAlertsChannels":
+				return ec.fieldContext_Team_slackAlertsChannels(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -3090,6 +3149,8 @@ func (ec *executionContext) fieldContext_Mutation_setAzureADGroupId(ctx context.
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
 			case "slackChannel":
 				return ec.fieldContext_Team_slackChannel(ctx, field)
+			case "slackAlertsChannels":
+				return ec.fieldContext_Team_slackAlertsChannels(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -3187,6 +3248,8 @@ func (ec *executionContext) fieldContext_Mutation_setGcpProjectId(ctx context.Co
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
 			case "slackChannel":
 				return ec.fieldContext_Team_slackChannel(ctx, field)
+			case "slackAlertsChannels":
+				return ec.fieldContext_Team_slackAlertsChannels(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -3284,6 +3347,8 @@ func (ec *executionContext) fieldContext_Mutation_setNaisNamespace(ctx context.C
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
 			case "slackChannel":
 				return ec.fieldContext_Team_slackChannel(ctx, field)
+			case "slackAlertsChannels":
+				return ec.fieldContext_Team_slackAlertsChannels(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -3753,6 +3818,8 @@ func (ec *executionContext) fieldContext_Mutation_createTeam(ctx context.Context
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
 			case "slackChannel":
 				return ec.fieldContext_Team_slackChannel(ctx, field)
+			case "slackAlertsChannels":
+				return ec.fieldContext_Team_slackAlertsChannels(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -3850,6 +3917,8 @@ func (ec *executionContext) fieldContext_Mutation_updateTeam(ctx context.Context
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
 			case "slackChannel":
 				return ec.fieldContext_Team_slackChannel(ctx, field)
+			case "slackAlertsChannels":
+				return ec.fieldContext_Team_slackAlertsChannels(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -3947,6 +4016,8 @@ func (ec *executionContext) fieldContext_Mutation_removeUsersFromTeam(ctx contex
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
 			case "slackChannel":
 				return ec.fieldContext_Team_slackChannel(ctx, field)
+			case "slackAlertsChannels":
+				return ec.fieldContext_Team_slackAlertsChannels(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -4195,6 +4266,8 @@ func (ec *executionContext) fieldContext_Mutation_addTeamMembers(ctx context.Con
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
 			case "slackChannel":
 				return ec.fieldContext_Team_slackChannel(ctx, field)
+			case "slackAlertsChannels":
+				return ec.fieldContext_Team_slackAlertsChannels(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -4292,6 +4365,8 @@ func (ec *executionContext) fieldContext_Mutation_addTeamOwners(ctx context.Cont
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
 			case "slackChannel":
 				return ec.fieldContext_Team_slackChannel(ctx, field)
+			case "slackAlertsChannels":
+				return ec.fieldContext_Team_slackAlertsChannels(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -4389,6 +4464,8 @@ func (ec *executionContext) fieldContext_Mutation_setTeamMemberRole(ctx context.
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
 			case "slackChannel":
 				return ec.fieldContext_Team_slackChannel(ctx, field)
+			case "slackAlertsChannels":
+				return ec.fieldContext_Team_slackAlertsChannels(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -4486,6 +4563,8 @@ func (ec *executionContext) fieldContext_Mutation_disableTeam(ctx context.Contex
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
 			case "slackChannel":
 				return ec.fieldContext_Team_slackChannel(ctx, field)
+			case "slackAlertsChannels":
+				return ec.fieldContext_Team_slackAlertsChannels(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -4583,6 +4662,8 @@ func (ec *executionContext) fieldContext_Mutation_enableTeam(ctx context.Context
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
 			case "slackChannel":
 				return ec.fieldContext_Team_slackChannel(ctx, field)
+			case "slackAlertsChannels":
+				return ec.fieldContext_Team_slackAlertsChannels(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -5026,6 +5107,8 @@ func (ec *executionContext) fieldContext_Query_teams(ctx context.Context, field 
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
 			case "slackChannel":
 				return ec.fieldContext_Team_slackChannel(ctx, field)
+			case "slackAlertsChannels":
+				return ec.fieldContext_Team_slackAlertsChannels(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -5112,6 +5195,8 @@ func (ec *executionContext) fieldContext_Query_team(ctx context.Context, field g
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
 			case "slackChannel":
 				return ec.fieldContext_Team_slackChannel(ctx, field)
+			case "slackAlertsChannels":
+				return ec.fieldContext_Team_slackAlertsChannels(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -6809,6 +6894,91 @@ func (ec *executionContext) fieldContext_ServiceAccount_roles(ctx context.Contex
 	return fc, nil
 }
 
+func (ec *executionContext) _SlackAlertsChannel_environment(ctx context.Context, field graphql.CollectedField, obj *model.SlackAlertsChannel) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SlackAlertsChannel_environment(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Environment, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SlackAlertsChannel_environment(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SlackAlertsChannel",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SlackAlertsChannel_channelName(ctx context.Context, field graphql.CollectedField, obj *model.SlackAlertsChannel) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SlackAlertsChannel_channelName(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ChannelName, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SlackAlertsChannel_channelName(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SlackAlertsChannel",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _SyncError_createdAt(ctx context.Context, field graphql.CollectedField, obj *model.SyncError) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_SyncError_createdAt(ctx, field)
 	if err != nil {
@@ -7409,11 +7579,14 @@ func (ec *executionContext) _Team_slackChannel(ctx context.Context, field graphq
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalOString2string(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Team_slackChannel(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -7424,6 +7597,56 @@ func (ec *executionContext) fieldContext_Team_slackChannel(ctx context.Context, 
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Team_slackAlertsChannels(ctx context.Context, field graphql.CollectedField, obj *db.Team) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Team_slackAlertsChannels(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Team().SlackAlertsChannels(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.SlackAlertsChannel)
+	fc.Result = res
+	return ec.marshalNSlackAlertsChannel2ᚕᚖgithubᚗcomᚋnaisᚋconsoleᚋpkgᚋgraphᚋmodelᚐSlackAlertsChannelᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Team_slackAlertsChannels(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Team",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "environment":
+				return ec.fieldContext_SlackAlertsChannel_environment(ctx, field)
+			case "channelName":
+				return ec.fieldContext_SlackAlertsChannel_channelName(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type SlackAlertsChannel", field.Name)
 		},
 	}
 	return fc, nil
@@ -7588,6 +7811,8 @@ func (ec *executionContext) fieldContext_TeamMembership_team(ctx context.Context
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
 			case "slackChannel":
 				return ec.fieldContext_Team_slackChannel(ctx, field)
+			case "slackAlertsChannels":
+				return ec.fieldContext_Team_slackAlertsChannels(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -7783,6 +8008,8 @@ func (ec *executionContext) fieldContext_TeamSync_team(ctx context.Context, fiel
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
 			case "slackChannel":
 				return ec.fieldContext_Team_slackChannel(ctx, field)
+			case "slackAlertsChannels":
+				return ec.fieldContext_Team_slackAlertsChannels(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -9967,6 +10194,42 @@ func (ec *executionContext) unmarshalInputReconcilerConfigInput(ctx context.Cont
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputSlackAlertsChannelInput(ctx context.Context, obj interface{}) (model.SlackAlertsChannelInput, error) {
+	var it model.SlackAlertsChannelInput
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"environment", "channelName"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "environment":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("environment"))
+			it.Environment, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "channelName":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("channelName"))
+			it.ChannelName, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputUpdateTeamInput(ctx context.Context, obj interface{}) (model.UpdateTeamInput, error) {
 	var it model.UpdateTeamInput
 	asMap := map[string]interface{}{}
@@ -9974,7 +10237,7 @@ func (ec *executionContext) unmarshalInputUpdateTeamInput(ctx context.Context, o
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"purpose", "slackChannel"}
+	fieldsInOrder := [...]string{"purpose", "slackChannel", "slackAlertsChannels"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -9994,6 +10257,14 @@ func (ec *executionContext) unmarshalInputUpdateTeamInput(ctx context.Context, o
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("slackChannel"))
 			it.SlackChannel, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "slackAlertsChannels":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("slackAlertsChannels"))
+			it.SlackAlertsChannels, err = ec.unmarshalOSlackAlertsChannelInput2ᚕᚖgithubᚗcomᚋnaisᚋconsoleᚋpkgᚋgraphᚋmodelᚐSlackAlertsChannelInputᚄ(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -11015,6 +11286,38 @@ func (ec *executionContext) _ServiceAccount(ctx context.Context, sel ast.Selecti
 	return out
 }
 
+var slackAlertsChannelImplementors = []string{"SlackAlertsChannel"}
+
+func (ec *executionContext) _SlackAlertsChannel(ctx context.Context, sel ast.SelectionSet, obj *model.SlackAlertsChannel) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, slackAlertsChannelImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("SlackAlertsChannel")
+		case "environment":
+
+			out.Values[i] = ec._SlackAlertsChannel_environment(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "channelName":
+
+			out.Values[i] = ec._SlackAlertsChannel_channelName(ctx, field, obj)
+
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var syncErrorImplementors = []string{"SyncError"}
 
 func (ec *executionContext) _SyncError(ctx context.Context, sel ast.SelectionSet, obj *model.SyncError) graphql.Marshaler {
@@ -11209,6 +11512,29 @@ func (ec *executionContext) _Team(ctx context.Context, sel ast.SelectionSet, obj
 
 			out.Values[i] = ec._Team_slackChannel(ctx, field, obj)
 
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
+		case "slackAlertsChannels":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Team_slackAlertsChannels(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return innerFunc(ctx)
+
+			})
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -12321,6 +12647,65 @@ func (ec *executionContext) marshalNRoleName2ᚕgithubᚗcomᚋnaisᚋconsoleᚋ
 	return ret
 }
 
+func (ec *executionContext) marshalNSlackAlertsChannel2ᚕᚖgithubᚗcomᚋnaisᚋconsoleᚋpkgᚋgraphᚋmodelᚐSlackAlertsChannelᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.SlackAlertsChannel) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNSlackAlertsChannel2ᚖgithubᚗcomᚋnaisᚋconsoleᚋpkgᚋgraphᚋmodelᚐSlackAlertsChannel(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNSlackAlertsChannel2ᚖgithubᚗcomᚋnaisᚋconsoleᚋpkgᚋgraphᚋmodelᚐSlackAlertsChannel(ctx context.Context, sel ast.SelectionSet, v *model.SlackAlertsChannel) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._SlackAlertsChannel(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNSlackAlertsChannelInput2ᚖgithubᚗcomᚋnaisᚋconsoleᚋpkgᚋgraphᚋmodelᚐSlackAlertsChannelInput(ctx context.Context, v interface{}) (*model.SlackAlertsChannelInput, error) {
+	res, err := ec.unmarshalInputSlackAlertsChannelInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalNSlug2githubᚗcomᚋnaisᚋconsoleᚋpkgᚋslugᚐSlug(ctx context.Context, v interface{}) (slug.Slug, error) {
 	res, err := slug.UnmarshalSlug(v)
 	return *res, graphql.ErrorOnPath(ctx, err)
@@ -13169,6 +13554,26 @@ func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast
 	return res
 }
 
+func (ec *executionContext) unmarshalOSlackAlertsChannelInput2ᚕᚖgithubᚗcomᚋnaisᚋconsoleᚋpkgᚋgraphᚋmodelᚐSlackAlertsChannelInputᚄ(ctx context.Context, v interface{}) ([]*model.SlackAlertsChannelInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]*model.SlackAlertsChannelInput, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNSlackAlertsChannelInput2ᚖgithubᚗcomᚋnaisᚋconsoleᚋpkgᚋgraphᚋmodelᚐSlackAlertsChannelInput(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
 func (ec *executionContext) unmarshalOSlug2ᚖgithubᚗcomᚋnaisᚋconsoleᚋpkgᚋslugᚐSlug(ctx context.Context, v interface{}) (*slug.Slug, error) {
 	if v == nil {
 		return nil, nil
@@ -13182,16 +13587,6 @@ func (ec *executionContext) marshalOSlug2ᚖgithubᚗcomᚋnaisᚋconsoleᚋpkg�
 		return graphql.Null
 	}
 	res := slug.MarshalSlug(v)
-	return res
-}
-
-func (ec *executionContext) unmarshalOString2string(ctx context.Context, v interface{}) (string, error) {
-	res, err := graphql.UnmarshalString(v)
-	return res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) marshalOString2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
-	res := graphql.MarshalString(v)
 	return res
 }
 

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -172,7 +172,7 @@ type ComplexityRoot struct {
 		Metadata           func(childComplexity int) int
 		Purpose            func(childComplexity int) int
 		ReconcilerState    func(childComplexity int) int
-		SlackAlertsChannel func(childComplexity int) int
+		SlackChannel       func(childComplexity int) int
 		Slug               func(childComplexity int) int
 		SyncErrors         func(childComplexity int) int
 	}
@@ -960,12 +960,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Team.ReconcilerState(childComplexity), true
 
-	case "Team.slackAlertsChannel":
-		if e.complexity.Team.SlackAlertsChannel == nil {
+	case "Team.slackChannel":
+		if e.complexity.Team.SlackChannel == nil {
 			break
 		}
 
-		return e.complexity.Team.SlackAlertsChannel(childComplexity), true
+		return e.complexity.Team.SlackChannel(childComplexity), true
 
 	case "Team.slug":
 		if e.complexity.Team.Slug == nil {
@@ -1610,8 +1610,8 @@ type Team {
     "Current reconciler state for the team."
     reconcilerState: ReconcilerState!
 
-    "Slack channel for NAIS alerts."
-    slackAlertsChannel: String
+    "Slack channel for the team."
+    slackChannel: String
 }
 
 "Reconciler state type."
@@ -1703,8 +1703,8 @@ input CreateTeamInput {
     "Team purpose."
     purpose: String!
 
-    "Specify the Slack channel where NAIS alerts will be sent."
-    slackAlertsChannel: String!
+    "Specify the Slack channel for the team."
+    slackChannel: String!
 }
 
 "Input for updating an existing team."
@@ -1713,7 +1713,7 @@ input UpdateTeamInput {
     purpose: String
 
     "Specify the Slack channel to update the existing value."
-    slackAlertsChannel: String
+    slackChannel: String
 }
 
 "Available team roles."
@@ -2894,8 +2894,8 @@ func (ec *executionContext) fieldContext_Mutation_setGitHubTeamSlug(ctx context.
 				return ec.fieldContext_Team_lastSuccessfulSync(ctx, field)
 			case "reconcilerState":
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
-			case "slackAlertsChannel":
-				return ec.fieldContext_Team_slackAlertsChannel(ctx, field)
+			case "slackChannel":
+				return ec.fieldContext_Team_slackChannel(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -2991,8 +2991,8 @@ func (ec *executionContext) fieldContext_Mutation_setGoogleWorkspaceGroupEmail(c
 				return ec.fieldContext_Team_lastSuccessfulSync(ctx, field)
 			case "reconcilerState":
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
-			case "slackAlertsChannel":
-				return ec.fieldContext_Team_slackAlertsChannel(ctx, field)
+			case "slackChannel":
+				return ec.fieldContext_Team_slackChannel(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -3088,8 +3088,8 @@ func (ec *executionContext) fieldContext_Mutation_setAzureADGroupId(ctx context.
 				return ec.fieldContext_Team_lastSuccessfulSync(ctx, field)
 			case "reconcilerState":
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
-			case "slackAlertsChannel":
-				return ec.fieldContext_Team_slackAlertsChannel(ctx, field)
+			case "slackChannel":
+				return ec.fieldContext_Team_slackChannel(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -3185,8 +3185,8 @@ func (ec *executionContext) fieldContext_Mutation_setGcpProjectId(ctx context.Co
 				return ec.fieldContext_Team_lastSuccessfulSync(ctx, field)
 			case "reconcilerState":
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
-			case "slackAlertsChannel":
-				return ec.fieldContext_Team_slackAlertsChannel(ctx, field)
+			case "slackChannel":
+				return ec.fieldContext_Team_slackChannel(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -3282,8 +3282,8 @@ func (ec *executionContext) fieldContext_Mutation_setNaisNamespace(ctx context.C
 				return ec.fieldContext_Team_lastSuccessfulSync(ctx, field)
 			case "reconcilerState":
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
-			case "slackAlertsChannel":
-				return ec.fieldContext_Team_slackAlertsChannel(ctx, field)
+			case "slackChannel":
+				return ec.fieldContext_Team_slackChannel(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -3751,8 +3751,8 @@ func (ec *executionContext) fieldContext_Mutation_createTeam(ctx context.Context
 				return ec.fieldContext_Team_lastSuccessfulSync(ctx, field)
 			case "reconcilerState":
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
-			case "slackAlertsChannel":
-				return ec.fieldContext_Team_slackAlertsChannel(ctx, field)
+			case "slackChannel":
+				return ec.fieldContext_Team_slackChannel(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -3848,8 +3848,8 @@ func (ec *executionContext) fieldContext_Mutation_updateTeam(ctx context.Context
 				return ec.fieldContext_Team_lastSuccessfulSync(ctx, field)
 			case "reconcilerState":
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
-			case "slackAlertsChannel":
-				return ec.fieldContext_Team_slackAlertsChannel(ctx, field)
+			case "slackChannel":
+				return ec.fieldContext_Team_slackChannel(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -3945,8 +3945,8 @@ func (ec *executionContext) fieldContext_Mutation_removeUsersFromTeam(ctx contex
 				return ec.fieldContext_Team_lastSuccessfulSync(ctx, field)
 			case "reconcilerState":
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
-			case "slackAlertsChannel":
-				return ec.fieldContext_Team_slackAlertsChannel(ctx, field)
+			case "slackChannel":
+				return ec.fieldContext_Team_slackChannel(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -4193,8 +4193,8 @@ func (ec *executionContext) fieldContext_Mutation_addTeamMembers(ctx context.Con
 				return ec.fieldContext_Team_lastSuccessfulSync(ctx, field)
 			case "reconcilerState":
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
-			case "slackAlertsChannel":
-				return ec.fieldContext_Team_slackAlertsChannel(ctx, field)
+			case "slackChannel":
+				return ec.fieldContext_Team_slackChannel(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -4290,8 +4290,8 @@ func (ec *executionContext) fieldContext_Mutation_addTeamOwners(ctx context.Cont
 				return ec.fieldContext_Team_lastSuccessfulSync(ctx, field)
 			case "reconcilerState":
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
-			case "slackAlertsChannel":
-				return ec.fieldContext_Team_slackAlertsChannel(ctx, field)
+			case "slackChannel":
+				return ec.fieldContext_Team_slackChannel(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -4387,8 +4387,8 @@ func (ec *executionContext) fieldContext_Mutation_setTeamMemberRole(ctx context.
 				return ec.fieldContext_Team_lastSuccessfulSync(ctx, field)
 			case "reconcilerState":
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
-			case "slackAlertsChannel":
-				return ec.fieldContext_Team_slackAlertsChannel(ctx, field)
+			case "slackChannel":
+				return ec.fieldContext_Team_slackChannel(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -4484,8 +4484,8 @@ func (ec *executionContext) fieldContext_Mutation_disableTeam(ctx context.Contex
 				return ec.fieldContext_Team_lastSuccessfulSync(ctx, field)
 			case "reconcilerState":
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
-			case "slackAlertsChannel":
-				return ec.fieldContext_Team_slackAlertsChannel(ctx, field)
+			case "slackChannel":
+				return ec.fieldContext_Team_slackChannel(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -4581,8 +4581,8 @@ func (ec *executionContext) fieldContext_Mutation_enableTeam(ctx context.Context
 				return ec.fieldContext_Team_lastSuccessfulSync(ctx, field)
 			case "reconcilerState":
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
-			case "slackAlertsChannel":
-				return ec.fieldContext_Team_slackAlertsChannel(ctx, field)
+			case "slackChannel":
+				return ec.fieldContext_Team_slackChannel(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -5024,8 +5024,8 @@ func (ec *executionContext) fieldContext_Query_teams(ctx context.Context, field 
 				return ec.fieldContext_Team_lastSuccessfulSync(ctx, field)
 			case "reconcilerState":
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
-			case "slackAlertsChannel":
-				return ec.fieldContext_Team_slackAlertsChannel(ctx, field)
+			case "slackChannel":
+				return ec.fieldContext_Team_slackChannel(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -5110,8 +5110,8 @@ func (ec *executionContext) fieldContext_Query_team(ctx context.Context, field g
 				return ec.fieldContext_Team_lastSuccessfulSync(ctx, field)
 			case "reconcilerState":
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
-			case "slackAlertsChannel":
-				return ec.fieldContext_Team_slackAlertsChannel(ctx, field)
+			case "slackChannel":
+				return ec.fieldContext_Team_slackChannel(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -7388,8 +7388,8 @@ func (ec *executionContext) fieldContext_Team_reconcilerState(ctx context.Contex
 	return fc, nil
 }
 
-func (ec *executionContext) _Team_slackAlertsChannel(ctx context.Context, field graphql.CollectedField, obj *db.Team) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Team_slackAlertsChannel(ctx, field)
+func (ec *executionContext) _Team_slackChannel(ctx context.Context, field graphql.CollectedField, obj *db.Team) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Team_slackChannel(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -7402,7 +7402,7 @@ func (ec *executionContext) _Team_slackAlertsChannel(ctx context.Context, field 
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.SlackAlertsChannel, nil
+		return obj.SlackChannel, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -7416,7 +7416,7 @@ func (ec *executionContext) _Team_slackAlertsChannel(ctx context.Context, field 
 	return ec.marshalOString2string(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Team_slackAlertsChannel(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Team_slackChannel(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Team",
 		Field:      field,
@@ -7586,8 +7586,8 @@ func (ec *executionContext) fieldContext_TeamMembership_team(ctx context.Context
 				return ec.fieldContext_Team_lastSuccessfulSync(ctx, field)
 			case "reconcilerState":
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
-			case "slackAlertsChannel":
-				return ec.fieldContext_Team_slackAlertsChannel(ctx, field)
+			case "slackChannel":
+				return ec.fieldContext_Team_slackChannel(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -7781,8 +7781,8 @@ func (ec *executionContext) fieldContext_TeamSync_team(ctx context.Context, fiel
 				return ec.fieldContext_Team_lastSuccessfulSync(ctx, field)
 			case "reconcilerState":
 				return ec.fieldContext_Team_reconcilerState(ctx, field)
-			case "slackAlertsChannel":
-				return ec.fieldContext_Team_slackAlertsChannel(ctx, field)
+			case "slackChannel":
+				return ec.fieldContext_Team_slackChannel(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Team", field.Name)
 		},
@@ -9894,7 +9894,7 @@ func (ec *executionContext) unmarshalInputCreateTeamInput(ctx context.Context, o
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"slug", "purpose", "slackAlertsChannel"}
+	fieldsInOrder := [...]string{"slug", "purpose", "slackChannel"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -9917,11 +9917,11 @@ func (ec *executionContext) unmarshalInputCreateTeamInput(ctx context.Context, o
 			if err != nil {
 				return it, err
 			}
-		case "slackAlertsChannel":
+		case "slackChannel":
 			var err error
 
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("slackAlertsChannel"))
-			it.SlackAlertsChannel, err = ec.unmarshalNString2string(ctx, v)
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("slackChannel"))
+			it.SlackChannel, err = ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -9974,7 +9974,7 @@ func (ec *executionContext) unmarshalInputUpdateTeamInput(ctx context.Context, o
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"purpose", "slackAlertsChannel"}
+	fieldsInOrder := [...]string{"purpose", "slackChannel"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -9989,11 +9989,11 @@ func (ec *executionContext) unmarshalInputUpdateTeamInput(ctx context.Context, o
 			if err != nil {
 				return it, err
 			}
-		case "slackAlertsChannel":
+		case "slackChannel":
 			var err error
 
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("slackAlertsChannel"))
-			it.SlackAlertsChannel, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("slackChannel"))
+			it.SlackChannel, err = ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -11205,9 +11205,9 @@ func (ec *executionContext) _Team(ctx context.Context, sel ast.SelectionSet, obj
 				return innerFunc(ctx)
 
 			})
-		case "slackAlertsChannel":
+		case "slackChannel":
 
-			out.Values[i] = ec._Team_slackAlertsChannel(ctx, field, obj)
+			out.Values[i] = ec._Team_slackChannel(ctx, field, obj)
 
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))

--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -66,6 +66,22 @@ type ReconcilerState struct {
 	NaisDeployKeyProvisioned *time.Time `json:"naisDeployKeyProvisioned"`
 }
 
+// Slack alerts channel type.
+type SlackAlertsChannel struct {
+	// The environment for the alerts sent to the channel.
+	Environment string `json:"environment"`
+	// The name of the Slack channel.
+	ChannelName *string `json:"channelName"`
+}
+
+// Slack alerts channel input.
+type SlackAlertsChannelInput struct {
+	// The environment for the alerts sent to the channel.
+	Environment string `json:"environment"`
+	// The name of the Slack channel.
+	ChannelName *string `json:"channelName"`
+}
+
 // Sync error type.
 type SyncError struct {
 	// Creation time of the error.
@@ -106,6 +122,8 @@ type UpdateTeamInput struct {
 	Purpose *string `json:"purpose"`
 	// Specify the Slack channel to update the existing value.
 	SlackChannel *string `json:"slackChannel"`
+	// A list of Slack channels for NAIS alerts.
+	SlackAlertsChannels []*SlackAlertsChannelInput `json:"slackAlertsChannels"`
 }
 
 // User sync type.

--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -20,8 +20,8 @@ type CreateTeamInput struct {
 	Slug *slug.Slug `json:"slug"`
 	// Team purpose.
 	Purpose string `json:"purpose"`
-	// Specify the Slack channel where NAIS alerts will be sent.
-	SlackAlertsChannel string `json:"slackAlertsChannel"`
+	// Specify the Slack channel for the team.
+	SlackChannel string `json:"slackChannel"`
 }
 
 // GCP project type.
@@ -105,7 +105,7 @@ type UpdateTeamInput struct {
 	// Specify team purpose to update the existing value.
 	Purpose *string `json:"purpose"`
 	// Specify the Slack channel to update the existing value.
-	SlackAlertsChannel *string `json:"slackAlertsChannel"`
+	SlackChannel *string `json:"slackChannel"`
 }
 
 // User sync type.

--- a/pkg/graph/model/sanitize.go
+++ b/pkg/graph/model/sanitize.go
@@ -6,7 +6,7 @@ import (
 
 func (input CreateTeamInput) Sanitize() CreateTeamInput {
 	input.Purpose = strings.TrimSpace(input.Purpose)
-	input.SlackAlertsChannel = strings.TrimSpace(input.SlackAlertsChannel)
+	input.SlackChannel = strings.TrimSpace(input.SlackChannel)
 	return input
 }
 
@@ -15,8 +15,8 @@ func (input UpdateTeamInput) Sanitize() UpdateTeamInput {
 		input.Purpose = ptr(strings.TrimSpace(*input.Purpose))
 	}
 
-	if input.SlackAlertsChannel != nil {
-		input.SlackAlertsChannel = ptr(strings.TrimSpace(*input.SlackAlertsChannel))
+	if input.SlackChannel != nil {
+		input.SlackChannel = ptr(strings.TrimSpace(*input.SlackChannel))
 	}
 
 	return input

--- a/pkg/graph/model/sanitize.go
+++ b/pkg/graph/model/sanitize.go
@@ -19,5 +19,16 @@ func (input UpdateTeamInput) Sanitize() UpdateTeamInput {
 		input.SlackChannel = ptr(strings.TrimSpace(*input.SlackChannel))
 	}
 
+	channels := make([]*SlackAlertsChannelInput, len(input.SlackAlertsChannels))
+	for i := range input.SlackAlertsChannels {
+		channel := *input.SlackAlertsChannels[i]
+		channel.Environment = strings.TrimSpace(channel.Environment)
+		if channel.ChannelName != nil {
+			channel.ChannelName = ptr(strings.TrimSpace(*channel.ChannelName))
+		}
+		channels[i] = &channel
+	}
+	input.SlackAlertsChannels = channels
+
 	return input
 }

--- a/pkg/graph/model/sanitize_test.go
+++ b/pkg/graph/model/sanitize_test.go
@@ -1,0 +1,60 @@
+package model_test
+
+import (
+	"testing"
+
+	"github.com/nais/console/pkg/graph/model"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateTeamInput_Sanitize(t *testing.T) {
+	input := model.CreateTeamInput{
+		Purpose:      " some purpose ",
+		SlackChannel: " #some-channel ",
+	}
+	sanitized := input.Sanitize()
+	assert.Equal(t, "some purpose", sanitized.Purpose)
+	assert.Equal(t, "#some-channel", sanitized.SlackChannel)
+
+	assert.Equal(t, " some purpose ", input.Purpose)
+	assert.Equal(t, " #some-channel ", input.SlackChannel)
+}
+
+func TestUdateTeamInput_Sanitize(t *testing.T) {
+	input := model.UpdateTeamInput{
+		Purpose:      ptr(" some purpose "),
+		SlackChannel: ptr(" #some-channel "),
+		SlackAlertsChannels: []*model.SlackAlertsChannelInput{
+			{
+				Environment: " foo ",
+				ChannelName: ptr(" #foo "),
+			},
+			{
+				Environment: " bar ",
+				ChannelName: ptr(" #bar "),
+			},
+			{
+				Environment: " baz ",
+			},
+		},
+	}
+	sanitized := input.Sanitize()
+	assert.Equal(t, "some purpose", *sanitized.Purpose)
+	assert.Equal(t, "#some-channel", *sanitized.SlackChannel)
+	assert.Equal(t, "foo", sanitized.SlackAlertsChannels[0].Environment)
+	assert.Equal(t, "#foo", *sanitized.SlackAlertsChannels[0].ChannelName)
+	assert.Equal(t, "bar", sanitized.SlackAlertsChannels[1].Environment)
+	assert.Equal(t, "#bar", *sanitized.SlackAlertsChannels[1].ChannelName)
+	assert.Equal(t, "baz", sanitized.SlackAlertsChannels[2].Environment)
+	assert.Nil(t, sanitized.SlackAlertsChannels[2].ChannelName)
+
+	assert.Equal(t, " some purpose ", *input.Purpose)
+	assert.Equal(t, " #some-channel ", *input.SlackChannel)
+	assert.Equal(t, " foo ", input.SlackAlertsChannels[0].Environment)
+	assert.Equal(t, " #foo ", *input.SlackAlertsChannels[0].ChannelName)
+	assert.Equal(t, " bar ", input.SlackAlertsChannels[1].Environment)
+	assert.Equal(t, " #bar ", *input.SlackAlertsChannels[1].ChannelName)
+	assert.Equal(t, " baz ", input.SlackAlertsChannels[2].Environment)
+	assert.Nil(t, input.SlackAlertsChannels[2].ChannelName)
+}

--- a/pkg/graph/model/validate.go
+++ b/pkg/graph/model/validate.go
@@ -34,8 +34,8 @@ func (input CreateTeamInput) Validate() error {
 		return apierror.ErrTeamPrefixRedundant
 	}
 
-	if !slackChannelNameRegex.MatchString(input.SlackAlertsChannel) {
-		return apierror.ErrTeamSlackAlertsChannel
+	if !slackChannelNameRegex.MatchString(input.SlackChannel) {
+		return apierror.ErrTeamSlackChannel
 	}
 
 	return nil
@@ -46,8 +46,8 @@ func (input UpdateTeamInput) Validate() error {
 		return apierror.ErrTeamPurpose
 	}
 
-	if input.SlackAlertsChannel != nil && !slackChannelNameRegex.MatchString(*input.SlackAlertsChannel) {
-		return apierror.ErrTeamSlackAlertsChannel
+	if input.SlackChannel != nil && !slackChannelNameRegex.MatchString(*input.SlackChannel) {
+		return apierror.ErrTeamSlackChannel
 	}
 
 	return nil

--- a/pkg/graph/model/validate_test.go
+++ b/pkg/graph/model/validate_test.go
@@ -12,7 +12,7 @@ func ptr[T any](value T) *T {
 	return &value
 }
 
-func TestCreateTeamInput_Validate_SlackAlertsChannel(t *testing.T) {
+func TestCreateTeamInput_Validate_SlackChannel(t *testing.T) {
 	tpl := model.CreateTeamInput{
 		Slug:    ptr(slug.Slug("valid-slug")),
 		Purpose: "valid purpose",
@@ -34,21 +34,21 @@ func TestCreateTeamInput_Validate_SlackAlertsChannel(t *testing.T) {
 	}
 
 	for _, s := range validChannels {
-		tpl.SlackAlertsChannel = s
-		assert.NoError(t, tpl.Validate(), "Slack alerts channel %q should pass validation, but didn't", tpl.SlackAlertsChannel)
+		tpl.SlackChannel = s
+		assert.NoError(t, tpl.Validate(), "Slack channel %q should pass validation, but didn't", tpl.SlackChannel)
 	}
 
 	for _, s := range invalidChannels {
-		tpl.SlackAlertsChannel = s
-		assert.Error(t, tpl.Validate(), "Slack alerts channel %q passed validation even if it should not", tpl.SlackAlertsChannel)
+		tpl.SlackChannel = s
+		assert.Error(t, tpl.Validate(), "Slack channel %q passed validation even if it should not", tpl.SlackChannel)
 	}
 }
 
 func TestCreateTeamInput_Validate_Slug(t *testing.T) {
 	tpl := model.CreateTeamInput{
-		Slug:               nil,
-		Purpose:            "valid purpose",
-		SlackAlertsChannel: "#channel",
+		Slug:         nil,
+		Purpose:      "valid purpose",
+		SlackChannel: "#channel",
 	}
 
 	validSlugs := []string{

--- a/pkg/graph/model/validate_test.go
+++ b/pkg/graph/model/validate_test.go
@@ -3,6 +3,8 @@ package model_test
 import (
 	"testing"
 
+	"github.com/nais/console/pkg/graph/apierror"
+
 	"github.com/nais/console/pkg/graph/model"
 	"github.com/nais/console/pkg/slug"
 	"github.com/stretchr/testify/assert"
@@ -88,4 +90,63 @@ func TestCreateTeamInput_Validate_Slug(t *testing.T) {
 		tpl.Slug = ptr(slug.Slug(s))
 		assert.Error(t, tpl.Validate(), "Slug %q passed validation even if it should not", tpl.Slug)
 	}
+}
+
+func TestUpdateTeamInput_Validate(t *testing.T) {
+	t.Run("valid data", func(t *testing.T) {
+		input := model.UpdateTeamInput{
+			Purpose:      ptr("valid purpose"),
+			SlackChannel: ptr("#valid-channel"),
+			SlackAlertsChannels: []*model.SlackAlertsChannelInput{
+				{
+					Environment: "prod",
+					ChannelName: ptr("#name"),
+				},
+			},
+		}
+		assert.Nil(t, input.Validate([]string{"prod"}))
+	})
+
+	t.Run("invalid purpose", func(t *testing.T) {
+		input := model.UpdateTeamInput{
+			Purpose: ptr(""),
+		}
+		assert.Error(t, apierror.ErrTeamPurpose, input.Validate([]string{"prod"}))
+	})
+
+	t.Run("invalid slack channel", func(t *testing.T) {
+		input := model.UpdateTeamInput{
+			Purpose:      ptr("purpose"),
+			SlackChannel: ptr("#a"),
+		}
+		assert.ErrorContains(t, input.Validate([]string{"prod"}), "The Slack channel does not fit the requirements")
+	})
+
+	t.Run("slack alerts channel with invalid environment", func(t *testing.T) {
+		input := model.UpdateTeamInput{
+			Purpose:      ptr("purpose"),
+			SlackChannel: ptr("#channel"),
+			SlackAlertsChannels: []*model.SlackAlertsChannelInput{
+				{
+					Environment: "invalid",
+					ChannelName: ptr("#channel"),
+				},
+			},
+		}
+		assert.ErrorContains(t, input.Validate([]string{"prod"}), "The specified environment is not valid")
+	})
+
+	t.Run("slack alerts channel with invalid name", func(t *testing.T) {
+		input := model.UpdateTeamInput{
+			Purpose:      ptr("purpose"),
+			SlackChannel: ptr("#channel"),
+			SlackAlertsChannels: []*model.SlackAlertsChannelInput{
+				{
+					Environment: "prod",
+					ChannelName: ptr("#a"),
+				},
+			},
+		}
+		assert.ErrorContains(t, input.Validate([]string{"prod"}), "The Slack channel does not fit the requirements")
+	})
 }

--- a/pkg/graph/teams.go
+++ b/pkg/graph/teams.go
@@ -43,7 +43,7 @@ func (r *mutationResolver) CreateTeam(ctx context.Context, input model.CreateTea
 
 	var team *db.Team
 	err = r.database.Transaction(ctx, func(ctx context.Context, dbtx db.Database) error {
-		team, err = dbtx.CreateTeam(ctx, *input.Slug, input.Purpose, input.SlackAlertsChannel)
+		team, err = dbtx.CreateTeam(ctx, *input.Slug, input.Purpose, input.SlackChannel)
 		if err != nil {
 			return err
 		}
@@ -102,7 +102,7 @@ func (r *mutationResolver) UpdateTeam(ctx context.Context, slug *slug.Slug, inpu
 		return nil, fmt.Errorf("create log correlation ID: %w", err)
 	}
 
-	team, err = r.database.UpdateTeam(ctx, team.Slug, input.Purpose, input.SlackAlertsChannel)
+	team, err = r.database.UpdateTeam(ctx, team.Slug, input.Purpose, input.SlackChannel)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/graph/teams.go
+++ b/pkg/graph/teams.go
@@ -92,7 +92,7 @@ func (r *mutationResolver) UpdateTeam(ctx context.Context, slug *slug.Slug, inpu
 	}
 
 	input = input.Sanitize()
-	err = input.Validate()
+	err = input.Validate(r.gcpEnvironments)
 	if err != nil {
 		return nil, err
 	}
@@ -102,21 +102,40 @@ func (r *mutationResolver) UpdateTeam(ctx context.Context, slug *slug.Slug, inpu
 		return nil, fmt.Errorf("create log correlation ID: %w", err)
 	}
 
-	team, err = r.database.UpdateTeam(ctx, team.Slug, input.Purpose, input.SlackChannel)
+	err = r.database.Transaction(ctx, func(ctx context.Context, dbtx db.Database) error {
+		team, err = dbtx.UpdateTeam(ctx, team.Slug, input.Purpose, input.SlackChannel)
+		if err != nil {
+			return err
+		}
+
+		if len(input.SlackAlertsChannels) > 0 {
+			for _, slackAlertsChannel := range input.SlackAlertsChannels {
+				var err error
+				if slackAlertsChannel.ChannelName == nil {
+					err = dbtx.RemoveSlackAlertsChannel(ctx, team.Slug, slackAlertsChannel.Environment)
+				} else {
+					err = dbtx.SetSlackAlertsChannel(ctx, team.Slug, slackAlertsChannel.Environment, *slackAlertsChannel.ChannelName)
+				}
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		targets := []auditlogger.Target{
+			auditlogger.TeamTarget(team.Slug),
+		}
+		fields := auditlogger.Fields{
+			Action:        sqlc.AuditActionGraphqlApiTeamUpdate,
+			CorrelationID: correlationID,
+			Actor:         actor,
+		}
+
+		return r.auditLogger.Logf(ctx, dbtx, targets, fields, "Team configuration saved")
+	})
 	if err != nil {
 		return nil, err
 	}
-
-	targets := []auditlogger.Target{
-		auditlogger.TeamTarget(team.Slug),
-	}
-	fields := auditlogger.Fields{
-		Action:        sqlc.AuditActionGraphqlApiTeamUpdate,
-		CorrelationID: correlationID,
-		Actor:         actor,
-	}
-
-	r.auditLogger.Logf(ctx, r.database, targets, fields, "Team configuration saved")
 
 	r.reconcileTeam(ctx, correlationID, *team)
 
@@ -725,6 +744,27 @@ func (r *teamResolver) ReconcilerState(ctx context.Context, obj *db.Team) (*mode
 		AzureADGroupID:            azureADState.GroupID,
 		NaisDeployKeyProvisioned:  naisDeployKeyState.Provisioned,
 	}, nil
+}
+
+// SlackAlertsChannels is the resolver for the slackAlertsChannels field.
+func (r *teamResolver) SlackAlertsChannels(ctx context.Context, obj *db.Team) ([]*model.SlackAlertsChannel, error) {
+	channels := make([]*model.SlackAlertsChannel, 0, len(r.gcpEnvironments))
+	existingChannels, err := r.database.GetSlackAlertsChannels(ctx, obj.Slug)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, environment := range r.gcpEnvironments {
+		var channel *string
+		if value, exists := existingChannels[environment]; exists {
+			channel = &value
+		}
+		channels = append(channels, &model.SlackAlertsChannel{
+			Environment: environment,
+			ChannelName: channel,
+		})
+	}
+	return channels, nil
 }
 
 // Team returns generated.TeamResolver implementation.

--- a/pkg/graph/teams_test.go
+++ b/pkg/graph/teams_test.go
@@ -68,9 +68,9 @@ func TestMutationResolver_CreateTeam(t *testing.T) {
 
 	t.Run("create team with empty purpose", func(t *testing.T) {
 		_, err := resolver.CreateTeam(ctx, model.CreateTeamInput{
-			Slug:               &teamSlug,
-			Purpose:            "  ",
-			SlackAlertsChannel: slackChannel,
+			Slug:         &teamSlug,
+			Purpose:      "  ",
+			SlackChannel: slackChannel,
 		})
 		assert.ErrorContains(t, err, "You must specify the purpose for your team")
 	})
@@ -114,9 +114,9 @@ func TestMutationResolver_CreateTeam(t *testing.T) {
 			Once()
 
 		returnedTeam, err := resolver.CreateTeam(ctx, model.CreateTeamInput{
-			Slug:               &teamSlug,
-			Purpose:            " some purpose ",
-			SlackAlertsChannel: slackChannel,
+			Slug:         &teamSlug,
+			Purpose:      " some purpose ",
+			SlackChannel: slackChannel,
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, createdTeam.Slug, returnedTeam.Slug)
@@ -160,9 +160,9 @@ func TestMutationResolver_CreateTeam(t *testing.T) {
 			Once()
 
 		returnedTeam, err := resolver.CreateTeam(saCtx, model.CreateTeamInput{
-			Slug:               &teamSlug,
-			Purpose:            " some purpose ",
-			SlackAlertsChannel: slackChannel,
+			Slug:         &teamSlug,
+			Purpose:      " some purpose ",
+			SlackChannel: slackChannel,
 		})
 
 		assert.NoError(t, err)

--- a/pkg/reconcilers/nais/namespace/reconciler.go
+++ b/pkg/reconcilers/nais/namespace/reconciler.go
@@ -213,7 +213,7 @@ func (r *naisNamespaceReconciler) createNamespace(ctx context.Context, team db.T
 			GroupEmail:         groupEmail,
 			AzureGroupID:       azureGroupID,
 			CNRMEmail:          cnrmEmail,
-			SlackAlertsChannel: team.SlackAlertsChannel,
+			SlackAlertsChannel: team.SlackChannel,
 		},
 	}
 

--- a/pkg/reconcilers/nais/namespace/reconciler_test.go
+++ b/pkg/reconcilers/nais/namespace/reconciler_test.go
@@ -37,7 +37,7 @@ func TestReconcile(t *testing.T) {
 		environment         = "dev"
 		clusterProjectID    = "cluster-dev-123"
 		cnrmEmail           = "cnrm-slug-cd03@cluster-dev-123.iam.gserviceaccount.com"
-		slackChannel        = "team-channel"
+		slackChannel        = "#team-channel"
 	)
 
 	ctx := context.Background()
@@ -230,6 +230,12 @@ func TestReconcile(t *testing.T) {
 			})).
 			Return(nil).
 			Once()
+		database.
+			On("GetSlackAlertsChannels", ctx, team.Slug).
+			Return(map[string]string{
+				environment: "#env-channel",
+			}, nil).
+			Once()
 
 		auditLogger := auditlogger.NewMockAuditLogger(t)
 		auditLogger.
@@ -254,7 +260,7 @@ func TestReconcile(t *testing.T) {
 		assert.Equal(t, teamProjectID, publishRequest.Data.GcpProject)
 		assert.Equal(t, googleWorkspaceEmail, publishRequest.Data.GroupEmail)
 		assert.Equal(t, cnrmEmail, publishRequest.Data.CNRMEmail)
-		assert.Equal(t, slackChannel, publishRequest.Data.SlackAlertsChannel)
+		assert.Equal(t, "#env-channel", publishRequest.Data.SlackAlertsChannel)
 		assert.Equal(t, azureGroupID.String(), publishRequest.Data.AzureGroupID)
 	})
 
@@ -319,6 +325,10 @@ func TestReconcile(t *testing.T) {
 			})).
 			Return(nil).
 			Once()
+		database.
+			On("GetSlackAlertsChannels", ctx, team.Slug).
+			Return(map[string]string{}, nil).
+			Once()
 
 		auditLogger := auditlogger.NewMockAuditLogger(t)
 		auditLogger.
@@ -344,6 +354,7 @@ func TestReconcile(t *testing.T) {
 		assert.Equal(t, googleWorkspaceEmail, publishRequest.Data.GroupEmail)
 		assert.Equal(t, cnrmEmail, publishRequest.Data.CNRMEmail)
 		assert.Equal(t, azureGroupID.String(), publishRequest.Data.AzureGroupID)
+		assert.Equal(t, slackChannel, publishRequest.Data.SlackAlertsChannel)
 	})
 
 	t.Run("create namespaces with additional legacy mappings", func(t *testing.T) {
@@ -404,6 +415,10 @@ func TestReconcile(t *testing.T) {
 			})).
 			Return(nil).
 			Once()
+		database.
+			On("GetSlackAlertsChannels", ctx, team.Slug).
+			Return(map[string]string{}, nil).
+			Once()
 
 		auditLogger := auditlogger.NewMockAuditLogger(t)
 		auditLogger.
@@ -450,6 +465,7 @@ func TestReconcile(t *testing.T) {
 					break
 				}
 			}
+			assert.Equal(t, slackChannel, publishRequest.Data.SlackAlertsChannel)
 		}
 		assert.Empty(t, expectedCNRMEmails)
 	})
@@ -513,6 +529,10 @@ func TestReconcile(t *testing.T) {
 				return len(state.Projects) == 0
 			})).
 			Return(nil).
+			Once()
+		database.
+			On("GetSlackAlertsChannels", ctx, team.Slug).
+			Return(map[string]string{}, nil).
 			Once()
 
 		r := nais_namespace_reconciler.New(database, auditLogger, gcp.Clusters{}, domain, managementProjectID, azureEnabled, pubsubClient, emptyMapping, emptyMap, log)

--- a/pkg/reconcilers/nais/namespace/reconciler_test.go
+++ b/pkg/reconcilers/nais/namespace/reconciler_test.go
@@ -37,11 +37,11 @@ func TestReconcile(t *testing.T) {
 		environment         = "dev"
 		clusterProjectID    = "cluster-dev-123"
 		cnrmEmail           = "cnrm-slug-cd03@cluster-dev-123.iam.gserviceaccount.com"
-		slackAlertChannel   = "team-alert-channel"
+		slackChannel        = "team-channel"
 	)
 
 	ctx := context.Background()
-	team := db.Team{Team: &sqlc.Team{Slug: teamSlug, SlackAlertsChannel: slackAlertChannel}}
+	team := db.Team{Team: &sqlc.Team{Slug: teamSlug, SlackChannel: slackChannel}}
 	input := reconcilers.Input{
 		CorrelationID: uuid.New(),
 		Team:          team,
@@ -254,7 +254,7 @@ func TestReconcile(t *testing.T) {
 		assert.Equal(t, teamProjectID, publishRequest.Data.GcpProject)
 		assert.Equal(t, googleWorkspaceEmail, publishRequest.Data.GroupEmail)
 		assert.Equal(t, cnrmEmail, publishRequest.Data.CNRMEmail)
-		assert.Equal(t, slackAlertChannel, publishRequest.Data.SlackAlertsChannel)
+		assert.Equal(t, slackChannel, publishRequest.Data.SlackAlertsChannel)
 		assert.Equal(t, azureGroupID.String(), publishRequest.Data.AzureGroupID)
 	})
 

--- a/pkg/sqlc/models.go
+++ b/pkg/sqlc/models.go
@@ -788,7 +788,7 @@ type Team struct {
 	Purpose            string
 	Enabled            bool
 	LastSuccessfulSync sql.NullTime
-	SlackAlertsChannel string
+	SlackChannel       string
 }
 
 type TeamMetadatum struct {

--- a/pkg/sqlc/models.go
+++ b/pkg/sqlc/models.go
@@ -783,6 +783,12 @@ type Session struct {
 	Expires time.Time
 }
 
+type SlackAlertsChannel struct {
+	TeamSlug    slug.Slug
+	Environment string
+	ChannelName string
+}
+
 type Team struct {
 	Slug               slug.Slug
 	Purpose            string

--- a/pkg/sqlc/querier.go
+++ b/pkg/sqlc/querier.go
@@ -45,6 +45,7 @@ type Querier interface {
 	GetServiceAccountRoles(ctx context.Context, serviceAccountID uuid.UUID) ([]*ServiceAccountRole, error)
 	GetServiceAccounts(ctx context.Context) ([]*ServiceAccount, error)
 	GetSessionByID(ctx context.Context, id uuid.UUID) (*Session, error)
+	GetSlackAlertsChannels(ctx context.Context, teamSlug slug.Slug) ([]*SlackAlertsChannel, error)
 	GetTeamBySlug(ctx context.Context, slug slug.Slug) (*Team, error)
 	GetTeamMembers(ctx context.Context, targetTeamSlug *slug.Slug) ([]*User, error)
 	GetTeamMetadata(ctx context.Context, teamSlug slug.Slug) ([]*TeamMetadatum, error)
@@ -60,6 +61,7 @@ type Querier interface {
 	IsFirstRun(ctx context.Context) (bool, error)
 	RemoveAllServiceAccountRoles(ctx context.Context, serviceAccountID uuid.UUID) error
 	RemoveApiKeysFromServiceAccount(ctx context.Context, serviceAccountID uuid.UUID) error
+	RemoveSlackAlertsChannel(ctx context.Context, arg RemoveSlackAlertsChannelParams) error
 	RemoveUserFromTeam(ctx context.Context, arg RemoveUserFromTeamParams) error
 	ResetReconcilerConfig(ctx context.Context, reconciler ReconcilerName) error
 	RevokeGlobalUserRole(ctx context.Context, arg RevokeGlobalUserRoleParams) error
@@ -67,6 +69,7 @@ type Querier interface {
 	SetReconcilerErrorForTeam(ctx context.Context, arg SetReconcilerErrorForTeamParams) error
 	SetReconcilerStateForTeam(ctx context.Context, arg SetReconcilerStateForTeamParams) error
 	SetSessionExpires(ctx context.Context, arg SetSessionExpiresParams) (*Session, error)
+	SetSlackAlertsChannel(ctx context.Context, arg SetSlackAlertsChannelParams) error
 	SetTeamMetadata(ctx context.Context, arg SetTeamMetadataParams) error
 	UpdateTeam(ctx context.Context, arg UpdateTeamParams) (*Team, error)
 	UpdateUser(ctx context.Context, arg UpdateUserParams) (*User, error)

--- a/pkg/sqlc/teams.sql.go
+++ b/pkg/sqlc/teams.sql.go
@@ -14,26 +14,26 @@ import (
 )
 
 const createTeam = `-- name: CreateTeam :one
-INSERT INTO teams (slug, purpose, slack_alerts_channel)
+INSERT INTO teams (slug, purpose, slack_channel)
 VALUES ($1, $2, $3)
-RETURNING slug, purpose, enabled, last_successful_sync, slack_alerts_channel
+RETURNING slug, purpose, enabled, last_successful_sync, slack_channel
 `
 
 type CreateTeamParams struct {
-	Slug               slug.Slug
-	Purpose            string
-	SlackAlertsChannel string
+	Slug         slug.Slug
+	Purpose      string
+	SlackChannel string
 }
 
 func (q *Queries) CreateTeam(ctx context.Context, arg CreateTeamParams) (*Team, error) {
-	row := q.db.QueryRow(ctx, createTeam, arg.Slug, arg.Purpose, arg.SlackAlertsChannel)
+	row := q.db.QueryRow(ctx, createTeam, arg.Slug, arg.Purpose, arg.SlackChannel)
 	var i Team
 	err := row.Scan(
 		&i.Slug,
 		&i.Purpose,
 		&i.Enabled,
 		&i.LastSuccessfulSync,
-		&i.SlackAlertsChannel,
+		&i.SlackChannel,
 	)
 	return &i, err
 }
@@ -42,7 +42,7 @@ const disableTeam = `-- name: DisableTeam :one
 UPDATE teams
 SET enabled = false
 WHERE slug = $1
-RETURNING slug, purpose, enabled, last_successful_sync, slack_alerts_channel
+RETURNING slug, purpose, enabled, last_successful_sync, slack_channel
 `
 
 func (q *Queries) DisableTeam(ctx context.Context, slug slug.Slug) (*Team, error) {
@@ -53,7 +53,7 @@ func (q *Queries) DisableTeam(ctx context.Context, slug slug.Slug) (*Team, error
 		&i.Purpose,
 		&i.Enabled,
 		&i.LastSuccessfulSync,
-		&i.SlackAlertsChannel,
+		&i.SlackChannel,
 	)
 	return &i, err
 }
@@ -62,7 +62,7 @@ const enableTeam = `-- name: EnableTeam :one
 UPDATE teams
 SET enabled = true
 WHERE slug = $1
-RETURNING slug, purpose, enabled, last_successful_sync, slack_alerts_channel
+RETURNING slug, purpose, enabled, last_successful_sync, slack_channel
 `
 
 func (q *Queries) EnableTeam(ctx context.Context, slug slug.Slug) (*Team, error) {
@@ -73,13 +73,13 @@ func (q *Queries) EnableTeam(ctx context.Context, slug slug.Slug) (*Team, error)
 		&i.Purpose,
 		&i.Enabled,
 		&i.LastSuccessfulSync,
-		&i.SlackAlertsChannel,
+		&i.SlackChannel,
 	)
 	return &i, err
 }
 
 const getTeamBySlug = `-- name: GetTeamBySlug :one
-SELECT slug, purpose, enabled, last_successful_sync, slack_alerts_channel FROM teams
+SELECT slug, purpose, enabled, last_successful_sync, slack_channel FROM teams
 WHERE slug = $1
 `
 
@@ -91,7 +91,7 @@ func (q *Queries) GetTeamBySlug(ctx context.Context, slug slug.Slug) (*Team, err
 		&i.Purpose,
 		&i.Enabled,
 		&i.LastSuccessfulSync,
-		&i.SlackAlertsChannel,
+		&i.SlackChannel,
 	)
 	return &i, err
 }
@@ -156,7 +156,7 @@ func (q *Queries) GetTeamMetadata(ctx context.Context, teamSlug slug.Slug) ([]*T
 }
 
 const getTeams = `-- name: GetTeams :many
-SELECT slug, purpose, enabled, last_successful_sync, slack_alerts_channel FROM teams
+SELECT slug, purpose, enabled, last_successful_sync, slack_channel FROM teams
 ORDER BY slug ASC
 `
 
@@ -174,7 +174,7 @@ func (q *Queries) GetTeams(ctx context.Context) ([]*Team, error) {
 			&i.Purpose,
 			&i.Enabled,
 			&i.LastSuccessfulSync,
-			&i.SlackAlertsChannel,
+			&i.SlackChannel,
 		); err != nil {
 			return nil, err
 		}
@@ -232,26 +232,26 @@ func (q *Queries) SetTeamMetadata(ctx context.Context, arg SetTeamMetadataParams
 const updateTeam = `-- name: UpdateTeam :one
 UPDATE teams
 SET purpose = COALESCE($1, purpose),
-    slack_alerts_channel = COALESCE($2, slack_alerts_channel)
+    slack_channel = COALESCE($2, slack_channel)
 WHERE slug = $3
-RETURNING slug, purpose, enabled, last_successful_sync, slack_alerts_channel
+RETURNING slug, purpose, enabled, last_successful_sync, slack_channel
 `
 
 type UpdateTeamParams struct {
-	Purpose            sql.NullString
-	SlackAlertsChannel sql.NullString
-	Slug               slug.Slug
+	Purpose      sql.NullString
+	SlackChannel sql.NullString
+	Slug         slug.Slug
 }
 
 func (q *Queries) UpdateTeam(ctx context.Context, arg UpdateTeamParams) (*Team, error) {
-	row := q.db.QueryRow(ctx, updateTeam, arg.Purpose, arg.SlackAlertsChannel, arg.Slug)
+	row := q.db.QueryRow(ctx, updateTeam, arg.Purpose, arg.SlackChannel, arg.Slug)
 	var i Team
 	err := row.Scan(
 		&i.Slug,
 		&i.Purpose,
 		&i.Enabled,
 		&i.LastSuccessfulSync,
-		&i.SlackAlertsChannel,
+		&i.SlackChannel,
 	)
 	return &i, err
 }

--- a/pkg/sqlc/users.sql.go
+++ b/pkg/sqlc/users.sql.go
@@ -97,7 +97,7 @@ func (q *Queries) GetUserByID(ctx context.Context, id uuid.UUID) (*User, error) 
 }
 
 const getUserTeams = `-- name: GetUserTeams :many
-SELECT teams.slug, teams.purpose, teams.enabled, teams.last_successful_sync, teams.slack_alerts_channel FROM user_roles
+SELECT teams.slug, teams.purpose, teams.enabled, teams.last_successful_sync, teams.slack_channel FROM user_roles
 JOIN teams ON teams.slug = user_roles.target_team_slug
 JOIN users ON users.id = user_roles.user_id
 WHERE user_roles.user_id = $1
@@ -118,7 +118,7 @@ func (q *Queries) GetUserTeams(ctx context.Context, userID uuid.UUID) ([]*Team, 
 			&i.Purpose,
 			&i.Enabled,
 			&i.LastSuccessfulSync,
-			&i.SlackAlertsChannel,
+			&i.SlackChannel,
 		); err != nil {
 			return nil, err
 		}

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -26,3 +26,5 @@ sql:
             go_type: github.com/nais/console/pkg/slug.Slug
           - column: user_roles.target_team_slug
             go_type: "*github.com/nais/console/pkg/slug.Slug"
+          - column: slack_alerts_channels.team_slug
+            go_type: github.com/nais/console/pkg/slug.Slug

--- a/sqlc/queries/teams.sql
+++ b/sqlc/queries/teams.sql
@@ -55,3 +55,18 @@ WHERE user_id = $1 AND target_team_slug = $2;
 -- name: SetLastSuccessfulSyncForTeam :exec
 UPDATE teams SET last_successful_sync = NOW()
 WHERE slug = $1;
+
+-- name: GetSlackAlertsChannels :many
+SELECT * FROM slack_alerts_channels
+WHERE team_slug = $1
+ORDER BY environment ASC;
+
+-- name: SetSlackAlertsChannel :exec
+INSERT INTO slack_alerts_channels (team_slug, environment, channel_name)
+VALUES ($1, $2, $3)
+ON CONFLICT (team_slug, environment) DO
+    UPDATE SET channel_name = $3;
+
+-- name: RemoveSlackAlertsChannel :exec
+DELETE FROM slack_alerts_channels
+WHERE team_slug = $1 AND environment = $2;

--- a/sqlc/queries/teams.sql
+++ b/sqlc/queries/teams.sql
@@ -1,5 +1,5 @@
 -- name: CreateTeam :one
-INSERT INTO teams (slug, purpose, slack_alerts_channel)
+INSERT INTO teams (slug, purpose, slack_channel)
 VALUES ($1, $2, $3)
 RETURNING *;
 
@@ -32,7 +32,7 @@ ON CONFLICT (team_slug, key) DO
 -- name: UpdateTeam :one
 UPDATE teams
 SET purpose = COALESCE(sqlc.narg(purpose), purpose),
-    slack_alerts_channel = COALESCE(sqlc.narg(slack_alerts_channel), slack_alerts_channel)
+    slack_channel = COALESCE(sqlc.narg(slack_channel), slack_channel)
 WHERE slug = sqlc.arg(slug)
 RETURNING *;
 

--- a/sqlc/schemas/0037_multiple_slack_channels.down.sql
+++ b/sqlc/schemas/0037_multiple_slack_channels.down.sql
@@ -1,5 +1,6 @@
 BEGIN;
 
+DROP TABLE slack_alerts_channels;
 ALTER TABLE teams RENAME column slack_channel TO slack_alerts_channel;
 
 COMMIT;

--- a/sqlc/schemas/0037_multiple_slack_channels.down.sql
+++ b/sqlc/schemas/0037_multiple_slack_channels.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE teams RENAME column slack_channel TO slack_alerts_channel;
+
+COMMIT;

--- a/sqlc/schemas/0037_multiple_slack_channels.up.sql
+++ b/sqlc/schemas/0037_multiple_slack_channels.up.sql
@@ -1,5 +1,12 @@
 BEGIN;
 
+CREATE TABLE slack_alerts_channels (
+    team_slug TEXT NOT NULL,
+    environment TEXT NOT NULL,
+    channel_name TEXT NOT NULL CONSTRAINT slack_alerts_channels_channel_name CHECK (channel_name ~ '^#[a-z0-9æøå_-]{2,80}$'),
+    PRIMARY KEY(team_slug, environment)
+);
+
 ALTER TABLE teams RENAME column slack_alerts_channel TO slack_channel;
 
 COMMIT;

--- a/sqlc/schemas/0037_multiple_slack_channels.up.sql
+++ b/sqlc/schemas/0037_multiple_slack_channels.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE teams RENAME column slack_alerts_channel TO slack_channel;
+
+COMMIT;


### PR DESCRIPTION
Instead of having a single Slack alerts channel for each team we want to specify a channel per GCP environment.

See #95 