### PR TITLE
Store a list of GitHub repositories accessable by the Console team in the state

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/go-chi/chi v1.5.4
 	github.com/go-chi/cors v1.2.0
 	github.com/golang-migrate/migrate/v4 v4.15.2
-	github.com/google/go-github/v48 v48.2.0
+	github.com/google/go-github/v50 v50.0.0
 	github.com/google/uuid v1.3.0
 	github.com/jackc/pgconn v1.13.0
 	github.com/jackc/pgtype v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -627,8 +627,8 @@ github.com/google/go-containerregistry v0.5.1/go.mod h1:Ct15B4yir3PLOP5jsy0GNeYV
 github.com/google/go-github/v39 v39.2.0/go.mod h1:C1s8C5aCC9L+JXIYpJM5GYytdX52vC1bLvHEF1IhBrE=
 github.com/google/go-github/v41 v41.0.0 h1:HseJrM2JFf2vfiZJ8anY2hqBjdfY1Vlj/K27ueww4gg=
 github.com/google/go-github/v41 v41.0.0/go.mod h1:XgmCA5H323A9rtgExdTcnDkcqp6S30AVACCBDOonIxg=
-github.com/google/go-github/v48 v48.2.0 h1:68puzySE6WqUY9KWmpOsDEQfDZsso98rT6pZcz9HqcE=
-github.com/google/go-github/v48 v48.2.0/go.mod h1:dDlehKBDo850ZPvCTK0sEqTCVWcrGl2LcDiajkYi89Y=
+github.com/google/go-github/v50 v50.0.0 h1:gdO1AeuSZZK4iYWwVbjni7zg8PIQhp7QfmPunr016Jk=
+github.com/google/go-github/v50 v50.0.0/go.mod h1:Ev4Tre8QoKiolvbpOSG3FIi4Mlon3S2Nt9W5JYqKiwA=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=

--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -44,6 +44,14 @@ autobind:
 # modelgen, the others will be allowed when binding to fields. Configure them to
 # your liking
 models:
+  GitHubRepository:
+    model:
+      - github.com/nais/console/pkg/reconcilers.GitHubRepository
+
+  GitHubRepositoryPermission:
+    model:
+      - github.com/nais/console/pkg/reconcilers.GitHubRepositoryPermission
+
   AuditAction:
     model:
       - github.com/nais/console/pkg/sqlc.AuditAction

--- a/graphql/teams.graphqls
+++ b/graphql/teams.graphqls
@@ -191,6 +191,27 @@ type Team {
 
     "A list of Slack channels for NAIS alerts. If no channel is specified for a given environment, NAIS will fallback to the slackChannel value."
     slackAlertsChannels: [SlackAlertsChannel!]!
+
+    "A list of GitHub repositories for the team."
+    gitHubRepositories: [GitHubRepository!]!
+}
+
+"GitHub repository type."
+type GitHubRepository {
+    "Name of the repository, with the org prefix."
+    name: String!
+
+    "A list of permissions given to the team for this repository."
+    permissions: [GitHubRepositoryPermission!]!
+}
+
+"GitHub repository permission type."
+type GitHubRepositoryPermission {
+    "Name of the permission."
+    name: String!
+
+    "Whether or not the permission is granted for the repository."
+    granted: Boolean!
 }
 
 "Slack alerts channel type."

--- a/pkg/graph/teams.go
+++ b/pkg/graph/teams.go
@@ -768,6 +768,16 @@ func (r *teamResolver) SlackAlertsChannels(ctx context.Context, obj *db.Team) ([
 	return channels, nil
 }
 
+// GitHubRepositories is the resolver for the gitHubRepositories field.
+func (r *teamResolver) GitHubRepositories(ctx context.Context, obj *db.Team) ([]*reconcilers.GitHubRepository, error) {
+	state := &reconcilers.GitHubState{}
+	err := r.database.LoadReconcilerStateForTeam(ctx, sqlc.ReconcilerNameGithubTeam, obj.Slug, state)
+	if err != nil {
+		return nil, apierror.Errorf("Unable to load the GitHub state for the team.")
+	}
+	return state.Repositories, nil
+}
+
 // Team returns generated.TeamResolver implementation.
 func (r *Resolver) Team() generated.TeamResolver { return &teamResolver{r} }
 

--- a/pkg/reconcilers/github/team/mock_teams_service.go
+++ b/pkg/reconcilers/github/team/mock_teams_service.go
@@ -5,7 +5,7 @@ package github_team_reconciler
 import (
 	context "context"
 
-	github "github.com/google/go-github/v48/github"
+	github "github.com/google/go-github/v50/github"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -198,6 +198,38 @@ func (_m *MockTeamsService) ListTeamMembersBySlug(ctx context.Context, org strin
 
 	var r2 error
 	if rf, ok := ret.Get(2).(func(context.Context, string, string, *github.TeamListTeamMembersOptions) error); ok {
+		r2 = rf(ctx, org, slug, opts)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
+// ListTeamReposBySlug provides a mock function with given fields: ctx, org, slug, opts
+func (_m *MockTeamsService) ListTeamReposBySlug(ctx context.Context, org string, slug string, opts *github.ListOptions) ([]*github.Repository, *github.Response, error) {
+	ret := _m.Called(ctx, org, slug, opts)
+
+	var r0 []*github.Repository
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, *github.ListOptions) []*github.Repository); ok {
+		r0 = rf(ctx, org, slug, opts)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*github.Repository)
+		}
+	}
+
+	var r1 *github.Response
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, *github.ListOptions) *github.Response); ok {
+		r1 = rf(ctx, org, slug, opts)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*github.Response)
+		}
+	}
+
+	var r2 error
+	if rf, ok := ret.Get(2).(func(context.Context, string, string, *github.ListOptions) error); ok {
 		r2 = rf(ctx, org, slug, opts)
 	} else {
 		r2 = ret.Error(2)

--- a/pkg/reconcilers/github/team/reconciler_test.go
+++ b/pkg/reconcilers/github/team/reconciler_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-github/v48/github"
+	"github.com/google/go-github/v50/github"
 	"github.com/google/uuid"
 	"github.com/nais/console/pkg/auditlogger"
 	helpers "github.com/nais/console/pkg/console"
@@ -81,6 +81,20 @@ func TestGitHubReconciler_getOrCreateTeam(t *testing.T) {
 			).
 			Return(
 				[]*github.User{},
+				&github.Response{Response: &http.Response{StatusCode: http.StatusOK}},
+				nil,
+			).
+			Once()
+		teamsService.
+			On(
+				"ListTeamReposBySlug",
+				ctx,
+				org,
+				teamSlug,
+				mock.Anything,
+			).
+			Return(
+				[]*github.Repository{},
 				&github.Response{Response: &http.Response{StatusCode: http.StatusOK}},
 				nil,
 			).
@@ -183,6 +197,20 @@ func TestGitHubReconciler_getOrCreateTeam(t *testing.T) {
 				nil,
 			).
 			Once()
+		teamsService.
+			On(
+				"ListTeamReposBySlug",
+				ctx,
+				org,
+				teamSlug,
+				mock.Anything,
+			).
+			Return(
+				[]*github.Repository{},
+				&github.Response{Response: &http.Response{StatusCode: http.StatusOK}},
+				nil,
+			).
+			Once()
 
 		configureSyncTeamInfo(teamsService, org, teamSlug, teamPurpose)
 		configureDeleteTeamIDP(teamsService, org, teamSlug)
@@ -255,6 +283,20 @@ func TestGitHubReconciler_getOrCreateTeam(t *testing.T) {
 				nil,
 			).
 			Once()
+		teamsService.
+			On(
+				"ListTeamReposBySlug",
+				ctx,
+				org,
+				existingSlug,
+				mock.Anything,
+			).
+			Return(
+				[]*github.Repository{},
+				&github.Response{Response: &http.Response{StatusCode: http.StatusOK}},
+				nil,
+			).
+			Once()
 
 		configureSyncTeamInfo(teamsService, org, existingSlug, teamPurpose)
 		configureDeleteTeamIDP(teamsService, org, existingSlug)
@@ -313,11 +355,6 @@ func TestGitHubReconciler_Reconcile(t *testing.T) {
 
 	systemName := github_team_reconciler.Name
 
-	auditLogger := auditlogger.NewMockAuditLogger(t)
-	auditLogger.
-		On("Logf", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-		Return(nil)
-
 	// Give the reconciler enough data to create an entire team from scratch,
 	// remove members that shouldn't be present, and add members that should.
 	t.Run("create everything from scratch", func(t *testing.T) {
@@ -354,6 +391,26 @@ func TestGitHubReconciler_Reconcile(t *testing.T) {
 
 		configureDeleteTeamIDP(teamsService, org, teamName)
 
+		teamsService.
+			On(
+				"ListTeamReposBySlug",
+				ctx,
+				org,
+				teamName,
+				mock.Anything,
+			).
+			Return(
+				[]*github.Repository{},
+				&github.Response{Response: &http.Response{StatusCode: http.StatusOK}},
+				nil,
+			).
+			Once()
+
+		auditLogger := auditlogger.NewMockAuditLogger(t)
+		auditLogger.
+			On("Logf", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(nil)
+
 		reconciler := github_team_reconciler.New(database, auditLogger, org, domain, teamsService, graphClient, log)
 		err := reconciler.Reconcile(ctx, input)
 		assert.NoError(t, err)
@@ -363,6 +420,8 @@ func TestGitHubReconciler_Reconcile(t *testing.T) {
 		teamsService := github_team_reconciler.NewMockTeamsService(t)
 		graphClient := github_team_reconciler.NewMockGraphClient(t)
 		database := db.NewMockDatabase(t)
+		log = logger.NewMockLogger(t)
+		auditLogger := auditlogger.NewMockAuditLogger(t)
 
 		database.
 			On("LoadReconcilerStateForTeam", ctx, systemName, team.Slug, mock.Anything).
@@ -374,16 +433,16 @@ func TestGitHubReconciler_Reconcile(t *testing.T) {
 			Return(nil).
 			Once()
 
-		teamsService.On("GetTeamBySlug", mock.Anything, org, "slug-from-state").
+		teamsService.
+			On("GetTeamBySlug", mock.Anything, org, "slug-from-state").
 			Return(nil, &github.Response{
 				Response: &http.Response{
 					StatusCode: http.StatusTeapot,
 					Status:     "418: I'm a teapot",
 					Body:       io.NopCloser(strings.NewReader("this is a body")),
 				},
-			}, nil).Once()
-
-		log = logger.NewMockLogger(t)
+			}, nil).
+			Once()
 
 		reconciler := github_team_reconciler.New(database, auditLogger, org, domain, teamsService, graphClient, log)
 		err := reconciler.Reconcile(ctx, input)

--- a/pkg/reconcilers/github/team/types.go
+++ b/pkg/reconcilers/github/team/types.go
@@ -3,7 +3,7 @@ package github_team_reconciler
 import (
 	"context"
 
-	"github.com/google/go-github/v48/github"
+	"github.com/google/go-github/v50/github"
 	"github.com/nais/console/pkg/auditlogger"
 	"github.com/nais/console/pkg/db"
 	"github.com/nais/console/pkg/logger"
@@ -22,6 +22,7 @@ type TeamsService interface {
 	ListTeamMembersBySlug(ctx context.Context, org, slug string, opts *github.TeamListTeamMembersOptions) ([]*github.User, *github.Response, error)
 	RemoveTeamMembershipBySlug(ctx context.Context, org, slug, user string) (*github.Response, error)
 	CreateOrUpdateIDPGroupConnectionsBySlug(ctx context.Context, org, team string, opts github.IDPGroupList) (*github.IDPGroupList, *github.Response, error)
+	ListTeamReposBySlug(ctx context.Context, org, slug string, opts *github.ListOptions) ([]*github.Repository, *github.Response, error)
 }
 
 // githubTeamReconciler creates teams on GitHub and connects users to them.

--- a/pkg/reconcilers/state.go
+++ b/pkg/reconcilers/state.go
@@ -12,7 +12,18 @@ type AzureState struct {
 }
 
 type GitHubState struct {
-	Slug *slug.Slug `json:"slug"`
+	Slug         *slug.Slug          `json:"slug"`
+	Repositories []*GitHubRepository `json:"repositories"`
+}
+
+type GitHubRepository struct {
+	Name        string                        `json:"name"`
+	Permissions []*GitHubRepositoryPermission `json:"permissions"`
+}
+
+type GitHubRepositoryPermission struct {
+	Name    string `json:"name"`
+	Granted bool   `json:"granted"`
 }
 
 type GoogleWorkspaceState struct {


### PR DESCRIPTION
This feature is needed by the GAR reconciler. See #103 